### PR TITLE
VM pool handling improvement

### DIFF
--- a/clusterConfigSchema.yml
+++ b/clusterConfigSchema.yml
@@ -15,3 +15,7 @@ clusters:
       node: ""
       bmc_user: "required if physical or bf"
       bmc_password: "required if physical or bf"
+    # optionally describe additional node attributes
+    hosts:
+    - name: "A"
+      images_path: "/path/to/pool/directory"

--- a/clusterDeployer.py
+++ b/clusterDeployer.py
@@ -191,6 +191,10 @@ class ClusterDeployer():
         print(lh.run("virsh net-start default"))
         print(lh.run("systemctl restart libvirtd"))
 
+      pool_name = self.images_pool_name()
+      print(lh.run(f"virsh pool-destroy {pool_name}"))
+      print(lh.run(f"virsh pool-undefine {pool_name}"))
+
       print(lh.run(f"ip link set eno1 nomaster"))
 
     def _preconfig(self):

--- a/clusterDeployer.py
+++ b/clusterDeployer.py
@@ -28,12 +28,20 @@ from extraConfigOvnK import ExtraConfigOvnK
 import paramiko
 import common
 
+def pool_initialized(lh, pool_name):
+  return lh.run(f"virsh pool-info {pool_name}").returncode == 0
+
 def setup_vms(masters, iso_path, images_path, pool_name):
   lh = host.LocalHost()
-  print(lh.run(f"virsh pool-define-as {pool_name} dir - - - - {images_path}"))
-  print(lh.run(f"mkdir -p {images_path}"))
-  print(lh.run(f"chmod a+rw {images_path}"))
-  print(lh.run(f"virsh pool-start {pool_name}"))
+
+  if not pool_initialized(lh, pool_name):
+    print(f"Initializing pool {pool_name}")
+    print(lh.run(f"virsh pool-define-as {pool_name} dir - - - - {images_path}"))
+    print(lh.run(f"mkdir -p {images_path}"))
+    print(lh.run(f"chmod a+rw {images_path}"))
+    print(lh.run(f"virsh pool-start {pool_name}"))
+  else:
+    print(f"Pool {pool_name} already initialized")
 
   pre = "virsh net-update default add ip-dhcp-host".split()
 

--- a/clustersConfig.py
+++ b/clustersConfig.py
@@ -99,7 +99,7 @@ class ClustersConfig():
             # all hosts
             for host_config in cc["hosts"]:
               if "images_path" not in host_config:
-                host_config["images_path"] = "/home/guests_images"
+                host_config["images_path"] = f'/home/{cc["name"]}_guests_images'
 
     def _apply_jinja(self, contents):
         def worker_number(a):

--- a/clustersConfig.py
+++ b/clustersConfig.py
@@ -84,6 +84,23 @@ class ClustersConfig():
             if not cc["version"].endswith("-multi"):
                 cc["version"] += "-multi"
 
+            if "hosts" not in cc:
+              cc["hosts"] = []
+
+            # creates hosts entries for each referenced node name
+            all_nodes = cc["masters"] + cc["workers"]
+            node_names = set(x["name"] for x in cc["hosts"])
+            for h in all_nodes:
+              if h["node"] not in node_names:
+                cc["hosts"].append({"name" : h["node"]})
+                node_names.add(h["node"])
+
+            # fill-in defaults value for required attributes on
+            # all hosts
+            for host_config in cc["hosts"]:
+              if "images_path" not in host_config:
+                host_config["images_path"] = "/home/guests_images"
+
     def _apply_jinja(self, contents):
         def worker_number(a):
             self._ensure_clusters_loaded()


### PR DESCRIPTION
this series implements the discussed pool changes:
- patch 1 allows pool directory configuration on per host basis via yaml, and changes the default to /home/images_path
- patch 2 allows destroying the cluster pool at teatdown time
- patch 3 explicitly checks the relevant pool is not initialized before creating it

Note: this does not introduces yet others hosts-level attributes (e.g. api_network_port), as they should go via separate changeset