### PR TITLE
safer VM creation

### DIFF
--- a/clusterDeployer.py
+++ b/clusterDeployer.py
@@ -76,7 +76,9 @@ def setup_all_vms(h: host.LocalHost, vms, iso_path, virsh_pool) -> list:
     for e in vms:
         print(f"starting vm {e}")
         futures.append(executor.submit(setup_vm, h, virsh_pool, e, iso_path))
-        time.sleep(5)
+
+        while not h.vm_is_running(e["name"]) and not futures[-1].done():
+            time.sleep(1)
 
     return futures
 

--- a/host.py
+++ b/host.py
@@ -6,6 +6,7 @@ import subprocess
 from collections import namedtuple
 import io
 import os
+import re
 import time
 import json
 import shlex
@@ -22,6 +23,10 @@ def sync_time(src, dst):
     return dst.run(f"sudo date -s \"{date}\"")
 
 class Host():
+    def vm_is_running(self, name: str) -> bool:
+        ret = self.run(f"virsh dominfo {name}")
+        return not ret.returncode and re.search("State:.*running", ret.out)
+
     def ipa(self) -> dict:
         return json.loads(self.run("ip -json a").out)
 


### PR DESCRIPTION
Cuncurrent VM creation can fail due to virt-installer limitation. Let's wait until the newly created VM is started before moving over to avoid failure on slow/busy hypervisors.