### PR TITLE
Automatically determine the network API port from GSheets

### DIFF
--- a/clusterDeployer.py
+++ b/clusterDeployer.py
@@ -228,7 +228,7 @@ class ClusterDeployer():
         return None
 
     def _validate_api_port(self, lh) -> Optional[str]:
-        if self._cc["network_api_port"]:
+        if self._cc["network_api_port"] == "auto":
             def carrier_no_addr(intf):
                 return not intf["addr_info"] and not "NO-CARRIER" in intf["flags"]
 

--- a/clustersConfig.py
+++ b/clustersConfig.py
@@ -21,6 +21,7 @@ class ClusterInfo:
     def __init__(self, name: str):
         self.name = name
         self.provision_host = ""
+        self.network_api_port = ""
         self.workers = []  # type: List[str]
 
 
@@ -89,8 +90,10 @@ class ClustersConfig():
                 cc["version"] = "4.12.0-multi"
             if "external_port" not in cc:
                 cc["external_port"] = "auto"
-            if "network_api_port" not in cc:
+            if "network_api_port" not in cc or cc["network_api_port"] == "auto":
                 cc["network_api_port"] = "auto"
+                if self._clusters[self._current_host].network_api_port:
+                    cc["network_api_port"] = self._clusters[self._current_host].network_api_port
 
             if "hosts" not in cc:
               cc["hosts"] = []
@@ -149,6 +152,7 @@ class ClustersConfig():
                 continue
             if e[7] == "yes":
                 cluster.provision_host = e[0]
+                cluster.network_api_port = e[3]
             elif e[7] == "no":
                 cluster.workers.append(e[0])
         self._clusters = {x.provision_host : x for x in self._clusters}


### PR DESCRIPTION
Some servers in our Lab have interface names that are different then other servers. For example "eno1" may not exist on some servers. Thus, the first interface with a carrier signal may not be the correct interface. In our GSheet we should make sure that the provisioning interface is aligned with the Provision Host column.