### PR TITLE
Remove existing kernel-modules if needed

### DIFF
--- a/extraConfigDpuInfra.py
+++ b/extraConfigDpuInfra.py
@@ -40,15 +40,21 @@ def install_remotelyh(ip, links):
 
     print("result:", rh.run("sudo rpm-ostree"))
 
+    current_kernel = rh.run("uname -a | awk {'print $3'}").out
     cmd = f"sudo rpm-ostree override replace {wd}/*.rpm"
     print(cmd)
     while True:
-        ret = rh.run(cmd).out.strip().split("\n")
-        if ret and ret[-1] == 'Run "systemctl reboot" to start a reboot':
+        out, err, ret = rh.run(cmd)
+        out = out.strip().split("\n")
+        if out and out[-1] == 'Run "systemctl reboot" to start a reboot':
             break
         else:
-            print(ret)
-            print("Output was something unexpected")
+            print(out)
+            print(err)
+            if f"cannot install both kernel-core-{want} and kernel-core-{current_kernel}" in err:
+                cmd = f"sudo rpm-ostree override replace {wd}/*.rpm --remove=kernel-modules-core-{current_kernel}"
+
+
 
     rh.run("sudo systemctl reboot")
     time.sleep(10)


### PR DESCRIPTION
Encountered the following error which would result in an infinite loop without any error output.

```
sudo rpm-ostree override replace working_dir/*.rpm Checking out tree 1441bb2... done
No enabled rpm-md repositories.
Importing rpm-md... done
Resolving dependencies... done
error: Could not depsolve transaction; 1 problem detected:
 Problem: package kernel-modules-core-5.14.0-282.el9.aarch64 requires kernel-uname-r = 5.14.0-282.el9.aarch64, but none of the providers can be installed
  - cannot install both kernel-core-4.18.0-372.35.1.el8_6.mr3440_221116_1544.aarch64 and kernel-core-5.14.0-282.el9.aarch64
  - conflicting requests
```