### PR TITLE
Add Device Plugin Management Port

### DIFF
--- a/clusterDeployer.py
+++ b/clusterDeployer.py
@@ -22,6 +22,7 @@ from extraConfigSriov import ExtraConfigSriov, ExtraConfigSriovOvSHWOL
 from extraConfigDpuTenant import ExtraConfigDpuTenantMC, ExtraConfigDpuTenant
 from extraConfigDpuInfra import ExtraConfigDpuInfra
 from extraConfigOvnK import ExtraConfigOvnK
+from extraConfigCNO import ExtraConfigCNO
 import paramiko
 import common
 from virshPool import VirshPool
@@ -100,6 +101,7 @@ class ExtraConfigRunner():
             "dpu_tenant_mc": ExtraConfigDpuTenantMC(cc),
             "dpu_tenant": ExtraConfigDpuTenant(cc),
             "ovnk8s": ExtraConfigOvnK(cc),
+            "cno": ExtraConfigCNO(cc),
         }
         self._extra_config = ec
 

--- a/clusterDeployer.py
+++ b/clusterDeployer.py
@@ -19,8 +19,8 @@ import socket
 import coreosBuilder
 from extraConfigBFB import ExtraConfigBFB, ExtraConfigSwitchNicMode
 from extraConfigSriov import ExtraConfigSriov, ExtraConfigSriovOvSHWOL, ExtraConfigSriovOvSHWOL_NewAPI
-from extraConfigDpuTenant import ExtraConfigDpuTenantMC, ExtraConfigDpuTenant
-from extraConfigDpuInfra import ExtraConfigDpuInfra
+from extraConfigDpuTenant import ExtraConfigDpuTenantMC, ExtraConfigDpuTenant, ExtraConfigDpuTenant_NewAPI
+from extraConfigDpuInfra import ExtraConfigDpuInfra, ExtraConfigDpuInfra_NewAPI
 from extraConfigOvnK import ExtraConfigOvnK
 from extraConfigCNO import ExtraConfigCNO
 import paramiko
@@ -99,8 +99,10 @@ class ExtraConfigRunner():
             "sriov_ovs_hwol": ExtraConfigSriovOvSHWOL(cc),
             "sriov_ovs_hwol_new_api": ExtraConfigSriovOvSHWOL_NewAPI(cc),
             "dpu_infra": ExtraConfigDpuInfra(cc),
+            "dpu_infra_new_api": ExtraConfigDpuInfra_NewAPI(cc),
             "dpu_tenant_mc": ExtraConfigDpuTenantMC(cc),
             "dpu_tenant": ExtraConfigDpuTenant(cc),
+            "dpu_tenant_new_api": ExtraConfigDpuTenant_NewAPI(cc),
             "ovnk8s": ExtraConfigOvnK(cc),
             "cno": ExtraConfigCNO(cc),
         }

--- a/clusterDeployer.py
+++ b/clusterDeployer.py
@@ -18,7 +18,7 @@ import requests
 import socket
 import coreosBuilder
 from extraConfigBFB import ExtraConfigBFB, ExtraConfigSwitchNicMode
-from extraConfigSriov import ExtraConfigSriov, ExtraConfigSriovOvSHWOL
+from extraConfigSriov import ExtraConfigSriov, ExtraConfigSriovOvSHWOL, ExtraConfigSriovOvSHWOL_NewAPI
 from extraConfigDpuTenant import ExtraConfigDpuTenantMC, ExtraConfigDpuTenant
 from extraConfigDpuInfra import ExtraConfigDpuInfra
 from extraConfigOvnK import ExtraConfigOvnK
@@ -97,6 +97,7 @@ class ExtraConfigRunner():
             "switch_to_nic_mode": ExtraConfigSwitchNicMode(cc),
             "sriov_network_operator": ExtraConfigSriov(cc),
             "sriov_ovs_hwol": ExtraConfigSriovOvSHWOL(cc),
+            "sriov_ovs_hwol_new_api": ExtraConfigSriovOvSHWOL_NewAPI(cc),
             "dpu_infra": ExtraConfigDpuInfra(cc),
             "dpu_tenant_mc": ExtraConfigDpuTenantMC(cc),
             "dpu_tenant": ExtraConfigDpuTenant(cc),

--- a/clusterDeployer.py
+++ b/clusterDeployer.py
@@ -19,7 +19,7 @@ import socket
 import coreosBuilder
 from extraConfigBFB import ExtraConfigBFB, ExtraConfigSwitchNicMode
 from extraConfigSriov import ExtraConfigSriov, ExtraConfigSriovOvSHWOL
-from extraConfigDpuTenant import ExtraConfigDpuTenant
+from extraConfigDpuTenant import ExtraConfigDpuTenantMC, ExtraConfigDpuTenant
 from extraConfigDpuInfra import ExtraConfigDpuInfra
 from extraConfigOvnK import ExtraConfigOvnK
 import paramiko
@@ -97,6 +97,7 @@ class ExtraConfigRunner():
             "sriov_network_operator": ExtraConfigSriov(cc),
             "sriov_ovs_hwol": ExtraConfigSriovOvSHWOL(cc),
             "dpu_infra": ExtraConfigDpuInfra(cc),
+            "dpu_tenant_mc": ExtraConfigDpuTenantMC(cc),
             "dpu_tenant": ExtraConfigDpuTenant(cc),
             "ovnk8s": ExtraConfigOvnK(cc),
         }

--- a/configCVO.py
+++ b/configCVO.py
@@ -1,0 +1,15 @@
+from k8sClient import K8sClient
+
+
+class ConfigCVO:
+    def scaleDown(self, client: K8sClient) -> None:
+        print("Scaling down the cluster-version-operator deployment.")
+        client.oc("scale --replicas=0 deploy/cluster-version-operator -n openshift-cluster-version")
+
+
+def main():
+    pass
+
+
+if __name__ == "__main__":
+    main()

--- a/configOperators.py
+++ b/configOperators.py
@@ -6,6 +6,11 @@ class ConfigCVO:
         print("Scaling down the cluster-version-operator deployment.")
         client.oc("scale --replicas=0 deploy/cluster-version-operator -n openshift-cluster-version")
 
+class ConfigCNO:
+    def scaleDown(self, client: K8sClient) -> None:
+        print("Scaling down the cluster-network-operator deployment.")
+        client.oc("scale --replicas=0 deploy/network-operator -n openshift-network-operator")
+
 
 def main():
     pass

--- a/extraConfigBFB.py
+++ b/extraConfigBFB.py
@@ -66,6 +66,7 @@ class ExtraConfigSwitchNicMode:
         self._cc = cc
 
     def run(self, _, futures: Dict[str, Future]) -> None:
+        [f.result() for (_, f) in futures.items()]
         client = K8sClient(self._cc["kubeconfig"])
 
         client.oc("create -f manifests/nicmode/pool.yaml")

--- a/extraConfigBFB.py
+++ b/extraConfigBFB.py
@@ -68,9 +68,6 @@ class ExtraConfigSwitchNicMode:
     def run(self, _, futures: Dict[str, Future]) -> None:
         client = K8sClient(self._cc["kubeconfig"])
 
-        ec = ExtraConfigSriov(self._cc)
-        ec.run(None)
-
         client.oc("create -f manifests/nicmode/pool.yaml")
 
         # label nodes

--- a/extraConfigCNO.py
+++ b/extraConfigCNO.py
@@ -1,0 +1,40 @@
+from k8sClient import K8sClient
+from configCVO import ConfigCVO
+import sys
+
+
+class ExtraConfigCNO:
+    def __init__(self, cc):
+        self._cc = cc
+
+    def run(self, cfg):
+        print("Running post config step to load custom CNO")
+        iclient = K8sClient(self._cc["kubeconfig"])
+
+        if "image" not in cfg:
+            print("Error image not provided to load custom CNO")
+            sys.exit(-1)
+
+        image = cfg["image"]
+
+        print(f"Image {image} provided to load custom CNO")
+
+        patch = f"""spec:
+  template:
+    spec:
+      containers:
+      - name: network-operator
+        image: {image}
+"""
+
+        configCVO = ConfigCVO()
+        configCVO.scaleDown(iclient)
+        iclient.oc(f'patch -p "{patch}" deploy network-operator -n openshift-network-operator')
+
+
+def main():
+    pass
+
+
+if __name__ == "__main__":
+    main()

--- a/extraConfigCNO.py
+++ b/extraConfigCNO.py
@@ -1,13 +1,15 @@
 from k8sClient import K8sClient
 from configCVO import ConfigCVO
 import sys
-
+from concurrent.futures import Future
+from typing import Dict
 
 class ExtraConfigCNO:
     def __init__(self, cc):
         self._cc = cc
 
-    def run(self, cfg):
+    def run(self, cfg, futures: Dict[str, Future]) -> None:
+        [f.result() for (_, f) in futures.items()]
         print("Running post config step to load custom CNO")
         iclient = K8sClient(self._cc["kubeconfig"])
 

--- a/extraConfigCNO.py
+++ b/extraConfigCNO.py
@@ -1,5 +1,5 @@
 from k8sClient import K8sClient
-from configCVO import ConfigCVO
+from configOperators import ConfigCVO
 import sys
 from concurrent.futures import Future
 from typing import Dict

--- a/extraConfigDpuInfra.py
+++ b/extraConfigDpuInfra.py
@@ -211,7 +211,8 @@ class ExtraConfigDpuInfra:
 
 # VF Management port requires a new API. We need a new extra config class to handle the API changes.
 class ExtraConfigDpuInfra_NewAPI(ExtraConfigDpuInfra):
-    def run(self, _):
+    def run(self, _, futures: Dict[str, Future]) -> None:
+        [f.result() for (_, f) in futures.items()]
         kc = "/root/kubeconfig.infracluster"
         client = K8sClient(kc)
         lh = host.LocalHost()

--- a/extraConfigDpuTenant.py
+++ b/extraConfigDpuTenant.py
@@ -166,7 +166,8 @@ class ExtraConfigDpuTenant:
         ec.ensure_pci_realloc(tclient, "dpu-host")
 
 class ExtraConfigDpuTenant_NewAPI(ExtraConfigDpuTenant):
-    def run(self, cfg):
+    def run(self, cfg, futures: Dict[str, Future]) -> None:
+        [f.result() for (_, f) in futures.items()]
         print("Running post config step")
         tclient = K8sClient("/root/kubeconfig.tenantcluster")
         print("Waiting for mcp dpu-host to become ready")

--- a/extraConfigDpuTenant.py
+++ b/extraConfigDpuTenant.py
@@ -165,6 +165,116 @@ class ExtraConfigDpuTenant:
         ec = ExtraConfigSriovOvSHWOL(self._cc)
         ec.ensure_pci_realloc(tclient, "dpu-host")
 
+class ExtraConfigDpuTenant_NewAPI(ExtraConfigDpuTenant):
+    def run(self, cfg):
+        print("Running post config step")
+        tclient = K8sClient("/root/kubeconfig.tenantcluster")
+        print("Waiting for mcp dpu-host to become ready")
+        tclient.oc("wait mcp dpu-host --for condition=updated --timeout=50m")
+
+        first_worker = self._cc["workers"][0]['name']
+        ip = tclient.get_ip(first_worker)
+        if ip is None:
+            sys.exit(-1)
+        rh = host.RemoteHost(ip)
+        rh.ssh_connect("core")
+        bf = [x for x in rh.run("lspci").out.split("\n") if "BlueField" in x]
+        if not bf:
+            print(f"Couldn't find BF on {first_worker}")
+            sys.exit(-1)
+        bf = bf[0].split(" ")[0]
+
+        print(f"BF is at {bf}")
+
+        bf_port = None
+        for port in rh.all_ports():
+            ret = rh.run(f'ethtool -i {port["ifname"]}')
+            if ret.returncode != 0:
+                continue
+
+            d = {}
+            for e in ret.out.strip().split("\n"):
+                key, value = e.split(":", 1)
+                d[key] = value
+            if d["bus-info"].endswith(bf):
+                bf_port = port["ifname"]
+        print(bf_port)
+
+        numVfs = 16
+        numMgmtVfs = 1
+        workloadPolicyName = "policy-mlnx-bf"
+        workloadResourceName = "mlnx_bf"
+        workloadBfPort = bf_port + f"#{numMgmtVfs}-{numVfs-1}"
+        workloadPolicyFile = "/tmp/" + workloadPolicyName + ".yaml"
+        mgmtPolicyName = "mgmt-policy-mlnx-bf"
+        mgmtResourceName = "mgmtvf"
+        mgmtBfPort = bf_port + f"#0-{numMgmtVfs-1}"
+        mgmtPolicyFile = "/tmp/" + mgmtPolicyName + ".yaml"
+
+        self.render_sriov_node_policy(workloadPolicyName, workloadBfPort, bf, numVfs, workloadResourceName, workloadPolicyFile)
+        self.render_sriov_node_policy(mgmtPolicyName, mgmtBfPort, bf, numVfs, mgmtResourceName, mgmtPolicyFile)
+
+        print("Creating sriov pool config")
+        tclient.oc("create -f manifests/tenant/sriov-pool-config.yaml")
+        tclient.oc("create -f " + workloadPolicyFile)
+        tclient.oc("create -f " + mgmtPolicyFile)
+        print("Waiting for mcp to be updated")
+        time.sleep(60)
+        tclient.oc("wait mcp dpu-host --for condition=updated --timeout=50m")
+
+        mgmtPortResourceName = "openshift.io/" + mgmtResourceName
+        print(f"Creating Config Map for mgmt port resource name {mgmtPortResourceName}")
+        with open('./manifests/tenant/hardware-offload-config.yaml.j2') as f:
+            j2_template = jinja2.Template(f.read())
+            rendered = j2_template.render(mgmtPortResourceName=mgmtPortResourceName)
+            print(rendered)
+
+        with open("/tmp/hardware-offload-config.yaml", "w") as outFile:
+            outFile.write(rendered)
+
+        print(tclient.oc("create -f /tmp/hardware-offload-config.yaml"))
+
+        print("creating mc to disable ovs")
+        tclient.oc("create -f manifests/tenant/disable-ovs.yaml")
+        print("Waiting for mcp")
+        time.sleep(60)
+        tclient.oc("wait mcp dpu-host --for condition=updated --timeout=50m")
+
+        for e in self._cc["workers"]:
+            cmd = f"label node {e['name']} network.operator.openshift.io/dpu-host="
+            print(tclient.oc(cmd))
+            rh = host.RemoteHost(tclient.get_ip(e['name']))
+            rh.ssh_connect("core")
+            # workaround for https://issues.redhat.com/browse/NHE-335
+            print(rh.run("sudo ovs-vsctl del-port br-int ovn-k8s-mp0"))
+
+        print("Final infrastructure cluster configuration")
+        iclient = K8sClient("/root/kubeconfig.infracluster")
+
+        # https://issues.redhat.com/browse/NHE-334
+        iclient.oc(f"project tenantcluster-dpu")
+        print(iclient.oc(f"create secret generic tenant-cluster-1-kubeconf --from-file=config={tclient._kc}"))
+
+        contents = open("manifests/tenant/envoverrides.yaml").read()
+        for e in cfg["mapping"]:
+            a = {}
+            a["TENANT_K8S_NODE"] = e['worker']
+            a["DPU_IP"] = iclient.get_ip(e['bf'])
+            a["MGMT_IFNAME"] = "eth1"
+            contents += f"  {e['bf']}: |\n"
+            for (k, v) in a.items():
+                contents += f"    {k}={v}\n"
+        open("/tmp/envoverrides.yaml", "w").write(contents)
+
+        iclient.oc("create -f /tmp/envoverrides.yaml")
+        r = iclient.oc(
+            "patch --type merge -p {\"spec\":{\"kubeConfigFile\":\"tenant-cluster-1-kubeconf\"}} OVNKubeConfig ovnkubeconfig-sample -n tenantcluster-dpu")
+        print(r)
+        print("Creating network attachement definition")
+        tclient.oc("create -f manifests/tenant/nad.yaml")
+
+        ec = ExtraConfigSriovOvSHWOL(self._cc)
+        ec.ensure_pci_realloc(tclient, "dpu-host")
 
 def create_nm_operator(client: K8sClient):
     print("Apply NMO subscription")

--- a/extraConfigOvnK.py
+++ b/extraConfigOvnK.py
@@ -1,13 +1,16 @@
 from k8sClient import K8sClient
 from configCVO import ConfigCVO
 import sys
+from concurrent.futures import Future
+from typing import Dict
 
 
 class ExtraConfigOvnK:
     def __init__(self, cc):
         self._cc = cc
 
-    def run(self, cfg):
+    def run(self, cfg, futures: Dict[str, Future]) -> None:
+        [f.result() for (_, f) in futures.items()]
         print("Running post config step to load custom OVN-K")
         iclient = K8sClient(self._cc["kubeconfig"])
 

--- a/extraConfigOvnK.py
+++ b/extraConfigOvnK.py
@@ -1,5 +1,5 @@
 from k8sClient import K8sClient
-from configCVO import ConfigCVO
+from configOperators import ConfigCVO
 import sys
 from concurrent.futures import Future
 from typing import Dict

--- a/extraConfigSriov.py
+++ b/extraConfigSriov.py
@@ -33,6 +33,12 @@ class ExtraConfigSriov:
         os.chdir(repo_dir)
         env = os.environ.copy()
         env["KUBECONFIG"] = client._kc
+
+        if "image" in cfg:
+            image = cfg["image"]
+            print(f"Image {image} provided to load custom sriov-network-operator")
+            env["SRIOV_NETWORK_OPERATOR_IMAGE"] = image
+
         # cleanup first, to make this script idempotent
         print("running make undeploy")
         print(lh.run("make undeploy", env))

--- a/extraConfigSriov.py
+++ b/extraConfigSriov.py
@@ -97,7 +97,8 @@ class ExtraConfigSriovOvSHWOL:
         with open(outfilename, "w") as outFile:
             outFile.write(rendered)
 
-    def run(self, _) -> None:
+    def run(self, _, futures: Dict[str, Future]) -> None:
+        [f.result() for (_, f) in futures.items()]
         client = K8sClient(self._cc["kubeconfig"])
         client.oc("create -f manifests/nicmode/pool.yaml")
 
@@ -162,7 +163,8 @@ class ExtraConfigSriovOvSHWOL:
 
 # VF Management port requires a new API. We need a new extra config class to handle the API changes.
 class ExtraConfigSriovOvSHWOL_NewAPI(ExtraConfigSriovOvSHWOL):
-    def run(self, _) -> None:
+    def run(self, _, futures: Dict[str, Future]) -> None:
+        [f.result() for (_, f) in futures.items()]
         client = K8sClient(self._cc["kubeconfig"])
         client.oc("create -f manifests/nicmode/pool.yaml")
 
@@ -238,10 +240,7 @@ class ExtraConfigSriovOvSHWOL_NewAPI(ExtraConfigSriovOvSHWOL):
         self.ensure_pci_realloc(client, "sriov")
 
 def main():
-    args = parse_args()
-    cc = ClustersConfig(args.config)
-    ec = ExtraConfigSriov(cc)
-    ec.run(None)
+    pass
 
 
 if __name__ == "__main__":

--- a/manifests/nicmode/hardware-offload-config.yaml.j2
+++ b/manifests/nicmode/hardware-offload-config.yaml.j2
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: hardware-offload-config
+    namespace: openshift-network-operator
+data:
+    dpu-host-mode-label: "network.operator.openshift.io/dpu-host"
+    dpu-mode-label: "network.operator.openshift.io/dpu"
+    smart-nic-mode-label: "network.operator.openshift.io/smart-nic"
+    mgmt-port-resource-name: {{mgmtPortResourceName}}

--- a/manifests/nicmode/sriov-node-policy.yaml.j2
+++ b/manifests/nicmode/sriov-node-policy.yaml.j2
@@ -1,7 +1,7 @@
 apiVersion: sriovnetwork.openshift.io/v1
 kind: SriovNetworkNodePolicy
 metadata:
-  name: sriov-node-policy
+  name: {{policyName}}
   namespace: openshift-sriov-network-operator
 spec:
   deviceType: netdevice
@@ -12,7 +12,7 @@ spec:
         - {{ line -}}
       {% endfor %}
   nodeSelector:
-    feature.node.kubernetes.io/network-sriov.capable: "true"
-  numVfs: 12
+    network.operator.openshift.io/smart-nic: ""
+  numVfs: {{numVfs}}
   priority: 5
-  resourceName: mlxnics
+  resourceName: {{resourceName}}

--- a/manifests/tenant/SriovNetworkNodePolicy.yaml.j2
+++ b/manifests/tenant/SriovNetworkNodePolicy.yaml.j2
@@ -1,16 +1,16 @@
 apiVersion: sriovnetwork.openshift.io/v1
 kind: SriovNetworkNodePolicy
 metadata:
-  name: policy-mlnx-bf
+  name: {{policyName}}
   namespace: openshift-sriov-network-operator
 spec:
-  resourceName: mlnx_bf
+  resourceName: {{resourceName}}
   nodeSelector:
     node-role.kubernetes.io/dpu-host: ""
   priority: 99
-  numVfs: 16
+  numVfs: {{numVfs}}
   nicSelector:
     vendor: "15b3"
     deviceId: "a2d6"
-    pfNames: ['{{bf_port}}#1-15']
+    pfNames: ['{{bf_port}}']
     rootDevices: ['0000:{{bf_addr}}']

--- a/manifests/tenant/hardware-offload-config.yaml.j2
+++ b/manifests/tenant/hardware-offload-config.yaml.j2
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: hardware-offload-config
+    namespace: openshift-network-operator
+data:
+    dpu-host-mode-label: "network.operator.openshift.io/dpu-host"
+    dpu-mode-label: "network.operator.openshift.io/dpu"
+    smart-nic-mode-label: "network.operator.openshift.io/smart-nic"
+    mgmt-port-resource-name: {{mgmtPortResourceName}}


### PR DESCRIPTION
These commits introduce changes to how post config works for DPU and NIC mode clusters:
```
NIC Mode:
    postconfig:
    - name: "sriov_network_operator"
    - name: "switch_to_nic_mode"
    - name: "sriov_ovs_hwol"
Infrastructure Cluster (No Change):
    postconfig:
    - name: "dpu_infra"
Tenant Cluster:
    postconfig:
    - name: "dpu_tenant_mc"
    - name: "sriov_network_operator"
    - name: "dpu_tenant"
      kubeconfig: "/root/kubeconfig.infracluster"
      mapping:
        - bf: bf-{{worker_number(0)}}
          worker: worker-{{worker_number(0)}}
        - bf: bf-{{worker_number(1)}}
          worker: worker-{{worker_number(1)}}
```
The "sriov_network_operator" must now be an explicit configuration step. This splits the dpu tenant extra config into 2 parts: "dpu_tenant_mc" and "dpu_tenant".

You could also provide images to CNO, OVN-K, and SR-IOV network operator. For example:
```
    - name: "cno"
      image: quay.io/.../cluster-network-operator
    - name: "ovnk8s"
      image: quay.io/.../ovn-kubernetes
    - name: "sriov_network_operator"
      image: quay.io/.../sriov-network-operator
```