### PR TITLE
fix TypeError

### DIFF
--- a/clustersConfig.py
+++ b/clustersConfig.py
@@ -146,7 +146,7 @@ class ClustersConfig():
         self._clusters = self._load_clusters()
         self._validate_clusters()
 
-    def _load_clusters(self) -> dict[str, ClusterInfo]:
+    def _load_clusters(self) -> Dict[str, ClusterInfo]:
         cluster = None
         ret = []
         print("loading cluster information")


### PR DESCRIPTION
Fixes the following error:

(ocp-venv) [root@wsfd-advnetlab228 cluster-deployment-automation]# python3.6 main.py ../nhe/cluster-deployment-automation-configs/config-nic-mode.yaml -t /usr/local/lib/python3.6/site-packages/paramiko/transport.py:33: CryptographyDeprecationWarning: Python 3.6 is no longer supported by the Python core team. Therefore, support for it is deprecated in cryptography. The next release of cryptography (40.0) will be the last to support Python 3.6.
  from cryptography.hazmat.backends import default_backend
Traceback (most recent call last):
  File "main.py", line 3, in <module>
    from clustersConfig import ClustersConfig
  File "/root/sal_cda_deploy/cluster-deployment-automation/clustersConfig.py", line 57, in <module>
    class ClustersConfig():
  File "/root/sal_cda_deploy/cluster-deployment-automation/clustersConfig.py", line 149, in ClustersConfig
    def _load_clusters(self) -> dict[str, ClusterInfo]:
TypeError: 'type' object is not subscriptable