### PR TITLE
Copy env-overrides to dpu operator ns

### DIFF
--- a/manifests/tenant/envoverrides.yaml
+++ b/manifests/tenant/envoverrides.yaml
@@ -2,5 +2,4 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: env-overrides
-  namespace: tenantcluster-dpu
-data:
+  namespace: 


### PR DESCRIPTION
github.com/openshift/dpu-network-operator/pull/60 requires that the mapping in env-overrides is available to the
openshift-dpu-network-operator ns.