### PR TITLE
Add debug info to mcp updates

### DIFF
--- a/extraConfigBFB.py
+++ b/extraConfigBFB.py
@@ -77,5 +77,9 @@ class ExtraConfigSwitchNicMode:
 
         client.oc("delete -f manifests/nicmode/switch.yaml")
         client.oc("create -f manifests/nicmode/switch.yaml")
+        print("Waiting for mcp to update")
+        start = time.time()
         time.sleep(60)
         print(client.oc("wait mcp sriov --for condition=updated --timeout=50m"))
+        minutes, seconds = divmod(int(time.time() - start), 60)
+        print(f"It took {minutes}m {seconds}s to for mcp sriov to update")

--- a/extraConfigDpuInfra.py
+++ b/extraConfigDpuInfra.py
@@ -191,8 +191,11 @@ class ExtraConfigDpuInfra:
         for b in bf_names:
             client.oc(f"label node {b} network.operator.openshift.io/dpu=")
         print("Waiting for mcp to be ready")
+        start = time.time()
         time.sleep(60)
         client.oc("wait mcp dpu --for condition=updated --timeout=50m")
+        minutes, seconds = divmod(int(time.time() - start), 60)
+        print(f"It took {minutes}m {seconds}s to for mcp dpu to update")
 
         for b in bf_names:
             ip = client.get_ip(b)
@@ -264,8 +267,11 @@ class ExtraConfigDpuInfra_NewAPI(ExtraConfigDpuInfra):
         for b in bf_names:
             client.oc(f"label node {b} network.operator.openshift.io/dpu=")
         print("Waiting for mcp to be ready")
+        start = time.time()
         time.sleep(60)
         client.oc("wait mcp dpu --for condition=updated --timeout=50m")
+        minutes, seconds = divmod(int(time.time() - start), 60)
+        print(f"It took {minutes}m {seconds}s to for mcp dpu to update")
 
         for b in bf_names:
             ip = client.get_ip(b)

--- a/extraConfigSriov.py
+++ b/extraConfigSriov.py
@@ -81,8 +81,11 @@ class ExtraConfigSriovOvSHWOL:
             outFile.write(rendered)
         client.oc("create -f /tmp/pci-realloc.yaml")
         print("Waiting for mcp")
+        start = time.time()
         time.sleep(60)
         client.oc(f"wait mcp {mcp_name} --for condition=updated --timeout=50m")
+        minutes, seconds = divmod(int(time.time() - start), 60)
+        print(f"It took {minutes}m {seconds}s to for mcp {mcp_name} to update")
 
     def ensure_pci_realloc(self, client: K8sClient, mcp_name: str) -> None:
         if self.need_pci_realloc(client):
@@ -156,8 +159,11 @@ class ExtraConfigSriovOvSHWOL:
         print(client.oc("create -f " + workloadPolicyFile))
         print(client.oc("create -f " + mgmtPolicyFile))
         print(client.oc("create -f manifests/nicmode/nad.yaml"))
+        start = time.time()
         time.sleep(60)
         print(client.oc("wait mcp sriov --for condition=updated --timeout=50m"))
+        minutes, seconds = divmod(int(time.time() - start), 60)
+        print(f"It took {minutes}m {seconds}s to for mcp sriov to update")
 
         self.ensure_pci_realloc(client, "sriov")
 
@@ -222,8 +228,11 @@ class ExtraConfigSriovOvSHWOL_NewAPI(ExtraConfigSriovOvSHWOL):
         print(client.oc("create -f " + workloadPolicyFile))
         print(client.oc("create -f " + mgmtPolicyFile))
         print(client.oc("create -f manifests/nicmode/nad.yaml"))
+        start = time.time()
         time.sleep(60)
         print(client.oc("wait mcp sriov --for condition=updated --timeout=50m"))
+        minutes, seconds = divmod(int(time.time() - start), 60)
+        print(f"It took {minutes}m {seconds}s to for mcp sriov to update")
 
         mgmtPortResourceName = "openshift.io/" + managementResourceName
         print(f"Creating Config Map for Hardware Offload with resource name {mgmtPortResourceName}")


### PR DESCRIPTION
The 'oc wait mcp ...' command occasionally returns before the MCP (MachineConfigPool) has been fully updated, leading to potential issues with reliability.

Improve reliability of 'oc wait mcp ...' command by adding debug output for verification.