### PR TITLE
Wait for each sriov resource to be applied

### DIFF
--- a/extraConfigBFB.py
+++ b/extraConfigBFB.py
@@ -80,8 +80,5 @@ class ExtraConfigSwitchNicMode:
         client.oc("delete -f manifests/nicmode/switch.yaml")
         client.oc("create -f manifests/nicmode/switch.yaml")
         logger.info("Waiting for mcp to update")
-        start = time.time()
-        time.sleep(60)
-        logger.info(client.oc("wait mcp sriov --for condition=updated --timeout=50m"))
-        minutes, seconds = divmod(int(time.time() - start), 60)
-        logger.info(f"It took {minutes}m {seconds}s to for mcp sriov to update")
+        client.wait_for_mcp("sriov", "switch.yaml")
+

--- a/extraConfigDpuInfra.py
+++ b/extraConfigDpuInfra.py
@@ -192,11 +192,7 @@ class ExtraConfigDpuInfra:
         for b in bf_names:
             client.oc(f"label node {b} network.operator.openshift.io/dpu=")
         logger.info("Waiting for mcp to be ready")
-        start = time.time()
-        time.sleep(60)
-        client.oc("wait mcp dpu --for condition=updated --timeout=50m")
-        minutes, seconds = divmod(int(time.time() - start), 60)
-        logger.info(f"It took {minutes}m {seconds}s to for mcp dpu to update")
+        client.wait_for_mcp("dpu", "cm.yaml")
 
         for b in bf_names:
             ip = client.get_ip(b)
@@ -268,11 +264,7 @@ class ExtraConfigDpuInfra_NewAPI(ExtraConfigDpuInfra):
         for b in bf_names:
             client.oc(f"label node {b} network.operator.openshift.io/dpu=")
         logger.info("Waiting for mcp to be ready")
-        start = time.time()
-        time.sleep(60)
-        client.oc("wait mcp dpu --for condition=updated --timeout=50m")
-        minutes, seconds = divmod(int(time.time() - start), 60)
-        logger.info(f"It took {minutes}m {seconds}s to for mcp dpu to update")
+        client.wait_for_mcp("dpu", "dpu mcp patch")
 
         for b in bf_names:
             ip = client.get_ip(b)

--- a/extraConfigSriov.py
+++ b/extraConfigSriov.py
@@ -82,11 +82,7 @@ class ExtraConfigSriovOvSHWOL:
             outFile.write(rendered)
         client.oc("create -f /tmp/pci-realloc.yaml")
         logger.info("Waiting for mcp")
-        start = time.time()
-        time.sleep(60)
-        client.oc(f"wait mcp {mcp_name} --for condition=updated --timeout=50m")
-        minutes, seconds = divmod(int(time.time() - start), 60)
-        logger.info(f"It took {minutes}m {seconds}s to for mcp {mcp_name} to update")
+        client.wait_for_mcp(mcp_name, "pci-realloc.yaml")
 
     def ensure_pci_realloc(self, client: K8sClient, mcp_name: str) -> None:
         if self.need_pci_realloc(client):
@@ -157,14 +153,13 @@ class ExtraConfigSriovOvSHWOL:
         self.render_sriov_node_policy(mgmtPolicyName, managementVFsAll, numVfs, managementResourceName, mgmtPolicyFile)
 
         logger.info(client.oc("create -f manifests/nicmode/sriov-pool-config.yaml"))
+        client.wait_for_mcp("sriov", "sriov-pool-config.yaml")
         logger.info(client.oc("create -f " + workloadPolicyFile))
+        client.wait_for_mcp("sriov", "sriov-workload-node-policy.yaml")
         logger.info(client.oc("create -f " + mgmtPolicyFile))
+        client.wait_for_mcp("sriov", "sriov-mgmt-node-policy.yaml")
         logger.info(client.oc("create -f manifests/nicmode/nad.yaml"))
-        start = time.time()
-        time.sleep(60)
-        logger.info(client.oc("wait mcp sriov --for condition=updated --timeout=50m"))
-        minutes, seconds = divmod(int(time.time() - start), 60)
-        logger.info(f"It took {minutes}m {seconds}s to for mcp sriov to update")
+        client.wait_for_mcp("sriov", "nad.yaml")
 
         self.ensure_pci_realloc(client, "sriov")
 
@@ -226,14 +221,13 @@ class ExtraConfigSriovOvSHWOL_NewAPI(ExtraConfigSriovOvSHWOL):
         self.render_sriov_node_policy(mgmtPolicyName, managementVFsAll, numVfs, managementResourceName, mgmtPolicyFile)
 
         logger.info(client.oc("create -f manifests/nicmode/sriov-pool-config.yaml"))
+        client.wait_for_mcp("sriov", "sriov-pool-config.yaml")
         logger.info(client.oc("create -f " + workloadPolicyFile))
+        client.wait_for_mcp("sriov", "sriov-workload-node-policy.yaml")
         logger.info(client.oc("create -f " + mgmtPolicyFile))
+        client.wait_for_mcp("sriov", "sriov-mgmt-node-policy.yaml")
         logger.info(client.oc("create -f manifests/nicmode/nad.yaml"))
-        start = time.time()
-        time.sleep(60)
-        logger.info(client.oc("wait mcp sriov --for condition=updated --timeout=50m"))
-        minutes, seconds = divmod(int(time.time() - start), 60)
-        logger.info(f"It took {minutes}m {seconds}s to for mcp sriov to update")
+        client.wait_for_mcp("sriov", "nad.yaml")
 
         mgmtPortResourceName = "openshift.io/" + managementResourceName
         logger.info(f"Creating Config Map for Hardware Offload with resource name {mgmtPortResourceName}")

--- a/k8sClient.py
+++ b/k8sClient.py
@@ -72,3 +72,15 @@ class K8sClient():
             lh.run("tar xf build/oc.tar.gz -C build")
             lh.run("rm build/oc.tar.gz")
         self.oc_bin = os.path.join(os.getcwd(), "build/oc")
+
+    def wait_for_mcp(self, mcp_name: str, resource: str = "resource"):
+        time.sleep(60)
+        iteration = 1
+        get_status_cmd = "get mcp sriov -o jsonpath='{.status.conditions[?(@.type==\"Updated\")].status}'"
+        while self.oc(get_status_cmd).out != "True":
+            start = time.time()
+            logger.info(self.oc(f"wait mcp {mcp_name} --for condition=updated --timeout=50m"))
+            minutes, seconds = divmod(int(time.time() - start), 60)
+            logger.info(f"It took {minutes}m {seconds}s to for {resource} to be applied (attempt: {iteration})")
+            iteration = iteration + 1
+            time.sleep(60)


### PR DESCRIPTION
On occasion an edge case can be reached where the initial wait for the sriov mcp to update is completed but a change is still pending, resulting in the nodes becoming 'unready' post script completion.

This results in failed CI runs due to the cluster being in an unexpected state.

Ensure each resource is successfully applied.