### PR TITLE
Postconfig for installing rt kernel on workers (and SNO)

### DIFF
--- a/clusterDeployer.py
+++ b/clusterDeployer.py
@@ -23,6 +23,7 @@ from extraConfigDpuTenant import ExtraConfigDpuTenantMC, ExtraConfigDpuTenant, E
 from extraConfigDpuInfra import ExtraConfigDpuInfra, ExtraConfigDpuInfra_NewAPI
 from extraConfigOvnK import ExtraConfigOvnK
 from extraConfigCNO import ExtraConfigCNO
+from extraConfigRT import ExtraConfigRT
 import paramiko
 import common
 from virshPool import VirshPool
@@ -170,6 +171,7 @@ class ExtraConfigRunner():
             "dpu_tenant_new_api": ExtraConfigDpuTenant_NewAPI(cc),
             "ovnk8s": ExtraConfigOvnK(cc),
             "cno": ExtraConfigCNO(cc),
+            "rt": ExtraConfigRT(cc),
         }
         self._extra_config = ec
 

--- a/clusterDeployer.py
+++ b/clusterDeployer.py
@@ -405,9 +405,6 @@ class ClusterDeployer():
             remote_masters = 0
         return remote_masters != 0 or remote_workers != 0
 
-    def _is_sno_configuration(self) -> bool:
-        return len(self._cc["masters"]) == 1 and len(self._cc["workers"]) == 0
-
     def deploy(self) -> None:
         self._validate()
 
@@ -437,7 +434,7 @@ class ClusterDeployer():
             logger.info("Skipping post configuration.")
 
     def _validate(self):
-        if self._is_sno_configuration():
+        if self._cc.is_sno():
             logger.info("Setting up a Single Node OpenShift (SNO) environment")
             self._cc["api_ip"] = self._cc["masters"][0]["ip"]
             self._cc["ingress_ip"] = self._cc["masters"][0]["ip"]
@@ -477,7 +474,7 @@ class ClusterDeployer():
         cfg["vip_dhcp_allocation"] = False
         cfg["additional_ntp_source"] = "clock.redhat.com"
         cfg["base_dns_domain"] = "redhat.com"
-        cfg["sno"] = self._is_sno_configuration()
+        cfg["sno"] = self._cc.is_sno()
 
         logger.info("Creating cluster")
         logger.info(cfg)

--- a/clustersConfig.py
+++ b/clustersConfig.py
@@ -208,6 +208,9 @@ class ClustersConfig():
     def local_vms(self) -> list:
         return [x for x in self.all_vms() if x["node"] == "localhost"]
 
+    def is_sno(self) -> bool:
+        return len(self["masters"]) == 1 and len(self["workers"]) == 0
+
 
 def main():
     pass

--- a/extraConfigRT.py
+++ b/extraConfigRT.py
@@ -1,0 +1,31 @@
+from k8sClient import K8sClient
+from logger import logger
+from concurrent.futures import Future
+from typing import Dict
+
+class ExtraConfigRT:
+    def __init__(self, cc):
+        self._cc = cc
+
+    def run(self, cfg, futures: Dict[str, Future]) -> None:
+        [f.result() for (_, f) in futures.items()]
+
+        is_sno = self._cc.is_sno()
+
+        logger.info("Running post config command to install rt kernel on worker nodes")
+        client = K8sClient(self._cc["kubeconfig"])
+
+        resource = "sno-realtime.yaml" if is_sno else "worker-realtime.yaml"
+        client.oc(f"create -f manifests/rt/{resource}")
+
+        logger.info("Waiting for mcp to update")
+        name = "master" if is_sno else "worker"
+        client.wait_for_mcp(name, resource)
+
+
+def main():
+    pass
+
+
+if __name__ == "__main__":
+    main()

--- a/manifests/rt/sno-realtime.yaml
+++ b/manifests/rt/sno-realtime.yaml
@@ -1,0 +1,8 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: "master"
+  name: 99-sno-realtime
+spec:
+  kernelType: realtime

--- a/manifests/rt/worker-realtime.yaml
+++ b/manifests/rt/worker-realtime.yaml
@@ -1,0 +1,8 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: "worker"
+  name: 99-worker-realtime
+spec:
+  kernelType: realtime


### PR DESCRIPTION
This adds logic to use a postconfig for installing a real-time kernel on worker nodes (or the single node in case of SNO). The manifest is included in `manifests` and not in-lined to give the user the ability to manually remove the machine config later on if needed (this is handy while making comparison tests).

Suggestions are welcomed as I'm not used to play with OCP. This was tested while setting up an OCP SNO in a virtual machine.

As a side note, I think documenting postconfigs would be nice. I did not include such a change here as I have no idea what the other postconfig do :)