### PR TITLE
Avoid (re)downloading iso for worker VMs (x86_64) if already present

### DIFF
--- a/coreosBuilder.py
+++ b/coreosBuilder.py
@@ -112,6 +112,7 @@ class CoreosBuilder():
         if os.path.exists(fcos_dir):
             shutil.rmtree(fcos_dir)
         os.makedirs(fcos_dir)
+        cur_dir = os.getcwd()
         os.chdir(fcos_dir)
 
         # -e COSA_NO_KVM=1 \
@@ -148,6 +149,7 @@ class CoreosBuilder():
             sys.exit(-1)
 
         self._embed_ign(embed_src, dst)
+        os.chdir(cur_dir)
 
     def _embed_ign(self, embed_src, dst):
         fn_ign = embed_src.replace(".iso", "-embed.ign")

--- a/host.py
+++ b/host.py
@@ -204,7 +204,7 @@ class Host:
     @retry(stop=stop_after_attempt(10), wait=wait_fixed(60))
     def _boot_with_overrides(self, iso_path: str) -> None:
         assert ":" in iso_path
-        logger.info(f"Trying to boot '{self._hostname}' through {self._bmc_url()}")
+        logger.info(f"Trying to boot '{self._hostname}' through {self._bmc_url()} using {iso_path}")
         red = self._redfish()
         try:
             red.eject_iso()


### PR DESCRIPTION
This also changes the directory used for the download, and set it to the current working directory.
Before this patch:
- masters downloaded to cwd and used iso in cwd
- workers downloaded in /root/iso, and used iso in cwd
- bf downloaded in /root/iso and used iso in /root/iso Now:
- masters download to cwd and uses iso in cwd (unchanged)
- workers download in ** cwd ** if iso not present, and uses iso in cwd
- bf download in /root/iso and uses iso in /root/iso (unchanged)

This speed-up installation time