### PR TITLE
Fix remote Host.write() calls.

### DIFF
--- a/clusterDeployer.py
+++ b/clusterDeployer.py
@@ -496,6 +496,9 @@ class ClusterDeployer():
             else:
                 logger.info("Skipping pre configuration.")
 
+            lh = host.LocalHost()
+            self.ensure_linked_to_bridge(lh)
+
             if "masters" in self.args.steps:
                 self.teardown()
                 self.create_cluster()
@@ -503,8 +506,6 @@ class ClusterDeployer():
             else:
                 logger.info("Skipping master creation.")
 
-            lh = host.LocalHost()
-            self.ensure_linked_to_bridge(lh)
             if "workers" in self.args.steps:
                 if self._cc["workers"]:
                     self.create_workers()

--- a/host.py
+++ b/host.py
@@ -414,7 +414,7 @@ class Host:
             with tempfile.NamedTemporaryFile(delete=False) as tmp_file:
                 tmp_filename = tmp_file.name
                 tmp_file.write(contents.encode('utf-8'))
-            self.copy_to(tmp_file, fn)
+            self.copy_to(tmp_filename, fn)
             os.remove(tmp_filename)
 
     def read_file(self, file_name: str) -> str:


### PR DESCRIPTION
Pass the file name instead of temp file object for non-local hosts.