### PR TITLE
clusterDeployer: Always update /etc/hosts with the current api_ip.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ gspread
 oauth2client
 jinja2
 kubernetes
+python-hosts


### PR DESCRIPTION
If the cluster name didn't change but the API IP did, the deployer didn't update /etc/hosts.

Move the /etc/hosts update earlier in the cluster bring up to allow accessing the API externally as early as possible.