### PR TITLE
clusterConfigSchema: Fix image_path attribute name.

### DIFF
--- a/clusterConfigSchema.yml
+++ b/clusterConfigSchema.yml
@@ -23,7 +23,7 @@ clusters:
     # optionally describe additional node attributes
     hosts:
     - name: "A"
-      images_path: "/path/to/pool/directory"
+      image_path: "/path/to/pool/directory"
       network_api_port: "<auto> to keep cluster default - <device name> to overwrite cluster default>"
       username: "<core> to connect to bms hosting vms"
       password: "password"


### PR DESCRIPTION
Commit c14c3c2bf8e3 ("Add capability to snapshot clusters (VMs only for now)") changed the attribute from 'images_path' to 'image_path' but didn't update the schema.