### PR TITLE
clusterDeployer: Only copy the worker ISO once per bare metal node.

### DIFF
--- a/clusterDeployer.py
+++ b/clusterDeployer.py
@@ -743,18 +743,17 @@ class ClusterDeployer:
             # TODO validate api port on rh
             self.ensure_linked_to_bridge(rh)
 
+            image_path = os.path.dirname(bm["image_path"])
+            rh.run(f"mkdir -p {image_path}")
+            rh.run(f"chmod a+rw {image_path}")
+            iso_src = os.path.join(os.getcwd(), f"{infra_env}.iso")
+            iso_path = os.path.join(image_path, f"{infra_env}.iso")
+            logger.info(f"Copying {iso_src} to {rh.hostname()}:/{iso_path}")
+            rh.copy_to(iso_src, iso_path)
+            logger.debug(f"iso_path is now {iso_path} for {rh.hostname()}")
+
             vm = list(x for x in self._cc["workers"] if x["type"] == "vm" and x["node"] == bm["node"])
-
             for e in vm:
-                image_path = os.path.dirname(e["image_path"])
-                rh.run(f"mkdir -p {image_path}")
-                rh.run(f"chmod a+rw {image_path}")
-                iso_src = os.path.join(os.getcwd(), f"{infra_env}.iso")
-                iso_path = os.path.join(image_path, f"{infra_env}.iso")
-                logger.debug(f"Copying {iso_src} to {rh.hostname()}:/{iso_path}")
-                rh.copy_to(iso_src, iso_path)
-                logger.debug(f"iso_path is now {iso_path} for {rh.hostname()}")
-
                 setup_dhcp_entry(lh, e)
 
             logger.debug(f"Starting {len(vm)} VMs on {bm['node']}")


### PR DESCRIPTION
The iso is the same for all nodes.  Log the operation at INFO level to make it more visible.