### PR TITLE
clusterDeployer: Update /etc/hosts after the AI cluster is up.

### DIFF
--- a/clusterDeployer.py
+++ b/clusterDeployer.py
@@ -557,9 +557,6 @@ class ClusterDeployer:
         self._ai.ensure_infraenv_created(infra_env, cfg)
         self._ai.download_iso_with_retry(infra_env)
 
-        logger.info('updating /etc/hosts')
-        self.update_etc_hosts()
-
         lh = host.LocalHost()
         # TODO: clean this up. Currently just skipping this
         # since self.local_host_config() is not present if no local vms
@@ -584,6 +581,10 @@ class ClusterDeployer:
         self._ai.download_kubeconfig(self._cc["name"], self._cc["kubeconfig"])
 
         self._ai.wait_cluster(cluster_name)
+
+        logger.info('updating /etc/hosts')
+        self.update_etc_hosts()
+
         for p in futures:
             p.result()
         self.ensure_linked_to_bridge(lh)


### PR DESCRIPTION
AI doesn't return a valid API VIP until at least one cluster node is up. The safest bet right now is to wait until `wait_cluster()` returns.  At that point nodes are up.

Fixes: b1d66d3a84e7 ("clusterDeployer: Always update /etc/hosts with the current api_ip.")