### PR TITLE
Host: Implement __str__() to get relevant error messages.

### DIFF
--- a/host.py
+++ b/host.py
@@ -40,6 +40,9 @@ class Result:
         self.err = err
         self.returncode = returncode
 
+    def __str__(self):
+        return f"(returncode: {self.returncode}, error: {self.err})"
+
 
 class Login(ABC):
     @abstractmethod


### PR DESCRIPTION
Without it we just log the Result object's address, e.g.:
  2023-10-26 06:51:00 INFO: Finished starting VM dceara-worker-1, cmd =
      virt-install
          --connect qemu:///system
          -n dceara-worker-1
          -r 32784
          --cpu host
          --vcpus 8
          --os-variant=rhel8.6
          --import
          --network bridge=virbr0,mac=52:54:6e:2e:94:8d
          --events on_reboot=restart
          --cdrom /home/dceara-cluster_guests_images/dceara-cluster-x86.iso
          --disk path=/home/dceara-cluster_guests_images/dceara-worker-1.qcow2
          --wait=-1
      , ret = <host.Result object at 0x7f174602d4f0>