### PR TITLE
NodeConfigs must be created before calling all_nodes()

### DIFF
--- a/assistedInstaller.py
+++ b/assistedInstaller.py
@@ -143,6 +143,6 @@ class AssistedClientAutomation(AssistedClient):  # type: ignore
         if "id" not in cluster_info:
             logger.error(f"ID is missing in cluster info for cluster {cluster_name}")
             sys.exit(-1)
-        if "api_ip" not in cluster_info:
+        if "api_vip" not in cluster_info:
             logger.error(f"Missing api ip in cluster info for cluster {cluster_name}")
-        return AssistedClientClusterInfo(cluster_info.id, cluster_info.api_vip)
+        return AssistedClientClusterInfo(cluster_info["id"], cluster_info["api_vip"])

--- a/clustersConfig.py
+++ b/clustersConfig.py
@@ -121,16 +121,8 @@ class ClustersConfig:
             cc["postconfig"] = []
         if "proxy" not in cc:
             cc["proxy"] = None
-
         if "hosts" not in cc:
             cc["hosts"] = []
-        # creates hosts entries for each referenced node name
-        node_names = set(x["name"] for x in cc["hosts"])
-        for node in self.all_nodes():
-            if node.node not in node_names:
-                cc["hosts"].append({"name": node.node})
-                node_names.add(node.node)
-
         if "proxy" in cc:
             self.proxy = cc["proxy"]
         if "noproxy" in cc:
@@ -155,6 +147,13 @@ class ClustersConfig:
             self.masters.append(NodeConfig(self.name, **n))
         for n in cc["workers"]:
             self.workers.append(NodeConfig(self.name, **n))
+        # creates hosts entries for each referenced node name
+        node_names = set(x["name"] for x in cc["hosts"])
+        for node in self.all_nodes():
+            if node.node not in node_names:
+                cc["hosts"].append({"name": node.node})
+                node_names.add(node.node)
+
         for e in cc["hosts"]:
             self.hosts.append(HostConfig(self.network_api_port, **e))
 

--- a/common.py
+++ b/common.py
@@ -23,7 +23,7 @@ class IPRouteAdressEntry:
 
 
 def ipa(host: host.Host) -> str:
-    return host.run("ip a -json").out
+    return host.run("ip -json a").out
 
 
 def ipa_to_entries(input: str) -> List[IPRouteAdressEntry]:
@@ -41,7 +41,7 @@ def ipa_to_entries(input: str) -> List[IPRouteAdressEntry]:
 
 
 def ipr(host: host.Host) -> str:
-    return host.run("ip r -json").out
+    return host.run("ip -json r").out
 
 
 @dataclass


### PR DESCRIPTION
We cannot use clustersConfigs.all_nodes() before appending the NodeConfig instances to self.masters / self.workers.

Fix some incorrect syntax in ip r commands