### PR TITLE
Fix sno installations which do not require an API or ingress IP.

### DIFF
--- a/clusterDeployer.py
+++ b/clusterDeployer.py
@@ -495,8 +495,6 @@ class ClusterDeployer:
             if self._cc.masters[0].ip is None:
                 logger.error("Missing ip on master")
                 sys.exit(-1)
-            self._cc.api_ip = self._cc.masters[0].ip
-            self._cc.ingress_ip = self._cc.masters[0].ip
 
         lh = host.LocalHost()
         min_cores = 28
@@ -531,8 +529,10 @@ class ClusterDeployer:
         cfg["pull_secret"] = self._secrets_path
         cfg["infraenv"] = "false"
 
-        cfg["api_ip"] = self._cc.api_ip
-        cfg["ingress_ip"] = self._cc.ingress_ip
+        if not self._cc.is_sno():
+            cfg["api_ip"] = self._cc.api_ip
+            cfg["ingress_ip"] = self._cc.ingress_ip
+
         cfg["vip_dhcp_allocation"] = False
         cfg["additional_ntp_source"] = "clock.redhat.com"
         cfg["base_dns_domain"] = "redhat.com"

--- a/clustersConfig.py
+++ b/clustersConfig.py
@@ -148,8 +148,6 @@ class ClustersConfig:
         if "network_api_port" in cc:
             self.network_api_port = cc["network_api_port"]
         self.name = cc["name"]
-        self.api_ip = cc["api_ip"]
-        self.ingress_ip = cc["ingress_ip"]
 
         self.kubeconfig = path.join(getcwd(), f'kubeconfig.{cc["name"]}')
         if "kubeconfig" in cc:
@@ -165,6 +163,10 @@ class ClustersConfig:
             if node.kind != "physical" and node.node not in node_names:
                 cc["hosts"].append({"name": node.node})
                 node_names.add(node.node)
+
+        if not self.is_sno():
+            self.api_ip = cc["api_ip"]
+            self.ingress_ip = cc["ingress_ip"]
 
         for e in cc["hosts"]:
             self.hosts.append(HostConfig(self.network_api_port, **e))


### PR DESCRIPTION
There were two issues with the current branch:
- The code assumed the ingress_ip and api_ip configuration was always present.
- The installer added some ingress_ip and api_ip checks before removing it from the SNO configuration. This patch does not add them in the first place.

Fixes #91