### PR TITLE
Bmc jinja parsing

### DIFF
--- a/clusterDeployer.py
+++ b/clusterDeployer.py
@@ -927,7 +927,7 @@ class ClusterDeployer:
             f = executor.submit(boot_iso_bf_helper, h, f"{infra_env_name}.iso")
             futures.append(f)
 
-        for (h, f) in zip(self._cc.workers, futures):
+        for h, f in zip(self._cc.workers, futures):
             h.ip = f.result()
             if h.ip is None:
                 logger.info(f"Couldn't find ip of worker {h.name}")

--- a/clusterInfo.py
+++ b/clusterInfo.py
@@ -13,6 +13,7 @@ class ClusterInfo:
         self.provision_host = ""
         self.network_api_port = ""
         self.workers = []  # type: List[str]
+        self.bmcs = []  # type: List[str]
 
 
 def read_sheet() -> List[List[str]]:
@@ -52,6 +53,11 @@ def load_all_cluster_info() -> Dict[str, ClusterInfo]:
             cluster.network_api_port = e[3]
         elif e[7] == "no":
             cluster.workers.append(e[0])
+            if "https://" in e[1]:
+                cluster.bmcs.append(e[1][8:])
+            else:
+                cluster.bmcs.append(e[1])
+
     if cluster is not None:
         ret.append(cluster)
     return {x.provision_host: x for x in ret}
@@ -66,7 +72,11 @@ def validate_cluster_info(cluster_info: ClusterInfo) -> None:
         sys.exit(-1)
     for e in cluster_info.workers:
         if e == "":
-            logger.info("Unnamed worker found for cluster {c.name}")
+            logger.info("Unnamed worker found for cluster {cluster_info.name}")
+            sys.exit(-1)
+    for e in cluster_info.bmcs:
+        if e == "":
+            logger.info("Unfilled IMPI address found for cluster {cluster_info.name}")
             sys.exit(-1)
 
 

--- a/clustersConfig.py
+++ b/clustersConfig.py
@@ -222,6 +222,11 @@ class ClustersConfig:
             assert self._cluster_info is not None
             return self._cluster_info.workers[a]
 
+        def bmc_ip(a: int) -> str:
+            self._ensure_clusters_loaded()
+            assert self._cluster_info is not None
+            return self._cluster_info.bmcs[a]
+
         def api_network() -> str:
             self._ensure_clusters_loaded()
             assert self._cluster_info is not None
@@ -233,6 +238,7 @@ class ClustersConfig:
         template.globals['worker_number'] = worker_number
         template.globals['worker_name'] = worker_name
         template.globals['api_network'] = api_network
+        template.globals['bmc_ip'] = bmc_ip
 
         kwargs = {}
         kwargs["cluster_name"] = cluster_name

--- a/extraConfigDpuTenant.py
+++ b/extraConfigDpuTenant.py
@@ -66,7 +66,7 @@ def render_envoverrides_cm(client: K8sClient, mapping: List[Dict[str, str]], ns:
             sys.exit(1)
         a["MGMT_IFNAME"] = "c1pf0vf0"
         contents += f"  {e['bf']}: |\n"
-        for (k, v) in a.items():
+        for k, v in a.items():
             contents += f"    {k}={v}\n"
 
     open(f"/tmp/envoverrides-{ns}.yaml", "w").write(contents)
@@ -155,7 +155,7 @@ def ExtraConfigDpuTenant(cc: ClustersConfig, cfg: ExtraConfigArgs, futures: Dict
         mp = re.sub('np\d$', '', bf_port)
         a["OVNKUBE_NODE_MGMT_PORT_NETDEV"] = f"{mp}v0"
         contents += f"  {bfmap['worker']}: |\n"
-        for (k, v) in a.items():
+        for k, v in a.items():
             contents += f"    {k}={v}\n"
     open("/tmp/1.yaml", "w").write(contents)
 


### PR DESCRIPTION
The IMPI addresses are no longer +1, as was previously the default. They can now accept jinja syntax to read a bmc_ip from the spreadsheet.

For example, you can now write `bmc_ip: "{{bmc_ip(0)}}"`

bmc_ip bug: https://issues.redhat.com/browse/NHE-934