### PR TITLE
Fix api_vip usage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ deactivate
 cat > cluster.yaml << EOF
 clusters:
   - name : "mycluster"
-    api_ip: "192.168.122.99"
+    api_vip: "192.168.122.99"
     ingress_ip: "192.168.122.101"
     masters:
     - name: "mycluster-master-1"
@@ -63,7 +63,7 @@ EOF
 cat > cluster.yaml << EOF
 clusters:
   - name : "vm"
-    api_ip: "192.168.122.99"
+    api_vip: "192.168.122.99"
     ingress_ip: "192.168.122.101"
     kubeconfig: "/root/kubeconfig.vm"
     masters:

--- a/assistedInstaller.py
+++ b/assistedInstaller.py
@@ -139,10 +139,16 @@ class AssistedClientAutomation(AssistedClient):  # type: ignore
         requests.post(f"http://{self.url}/api/assisted-install/v2/clusters/{uuid}/actions/allow-add-workers")
 
     def get_ai_cluster_info(self, cluster_name: str) -> AssistedClientClusterInfo:
-        cluster_info = self.info_cluster(cluster_name).to_dict()
-        if "id" not in cluster_info:
+        cluster_info = self.info_cluster(cluster_name)
+        if not hasattr(cluster_info, "id"):
             logger.error(f"ID is missing in cluster info for cluster {cluster_name}")
             sys.exit(-1)
-        if "api_vip" not in cluster_info:
-            logger.error(f"Missing api ip in cluster info for cluster {cluster_name}")
-        return AssistedClientClusterInfo(cluster_info["id"], cluster_info["api_vip"])
+        if not hasattr(cluster_info, "api_vips"):
+            logger.error(f"Missing api_vips in cluster info for cluster {cluster_name}")
+            sys.exit(-1)
+
+        if len(cluster_info.api_vips) == 0:
+            logger.error(f"Missing api vip in cluster info for cluster {cluster_name}")
+            sys.exit(-1)
+
+        return AssistedClientClusterInfo(cluster_info.id, cluster_info.api_vips[0].ip)

--- a/clusterDeployer.py
+++ b/clusterDeployer.py
@@ -523,14 +523,14 @@ class ClusterDeployer:
 
     def create_cluster(self) -> None:
         cluster_name = self._cc.name
-        cfg: Dict[str, Union[str, bool]] = {}
+        cfg: Dict[str, Union[str, bool, List[str], List[Dict[str, str]]]] = {}
         cfg["openshift_version"] = self._cc.version
         cfg["cpu_architecture"] = "multi"
         cfg["pull_secret"] = self._secrets_path
         cfg["infraenv"] = "false"
 
         if not self._cc.is_sno():
-            cfg["api_ip"] = self._cc.api_ip
+            cfg["api_vips"] = [self._cc.api_vip]
             cfg["ingress_ip"] = self._cc.ingress_ip
 
         cfg["vip_dhcp_allocation"] = False
@@ -971,11 +971,11 @@ class ClusterDeployer:
     def update_etc_hosts(self) -> None:
         cluster_name = self._cc.name
         api_name = f"api.{cluster_name}.redhat.com"
-        api_ip = self._ai.get_ai_cluster_info(cluster_name).api_vip
+        api_vip = self._ai.get_ai_cluster_info(cluster_name).api_vip
 
         hosts = Hosts()
         hosts.remove_all_matching(name=api_name)
-        hosts.add([HostsEntry(entry_type='ipv4', address=api_ip, names=[api_name])])
+        hosts.add([HostsEntry(entry_type='ipv4', address=api_vip, names=[api_name])])
         hosts.write()
 
         # libvirtd also runs dnsmasq, and dnsmasq reads /etc/hosts.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 GitPython
-aicli
+aicli==99.0.202401221550
 PyYAML
 requests
 setuptools-rust


### PR DESCRIPTION
Recently aicli stopped supporting `api_vip` and requires `api_vips` to be used instead (as a list).
Also, to avoid unexpected failures in the future, freeze the aicli version.