### PR TITLE
Add preconfig step to update CX firmware

### DIFF
--- a/extraConfigCX.py
+++ b/extraConfigCX.py
@@ -1,0 +1,49 @@
+from clustersConfig import ClustersConfig
+import host
+import coreosBuilder
+from concurrent.futures import ThreadPoolExecutor
+from k8sClient import K8sClient
+from nfs import NFS
+from concurrent.futures import Future
+from typing import Dict
+import sys
+from logger import logger
+from clustersConfig import ExtraConfigArgs
+
+"""
+The "ExtraConfigCX" is used to put the CX in a known good state. This is achieved by
+1) Having a CoreOS Fedora image ready and mounted on NFS. This is needed for loading
+a known good state on each of the workers.
+2) Then SSH-ing into the load CoreOS Fedora image, we can run a pod with all the BF2
+tools available. https://github.com/bn222/dpu-tools/
+3) The scripts will try to update the firmware of the CX with mlxup.
+4) Then the worker node is cold booted. This will also cold boot the CX.
+"""
+
+
+def ExtraConfigCX(cc: ClustersConfig, _: ExtraConfigArgs, futures: Dict[str, Future[None]]) -> None:
+    coreosBuilder.ensure_fcos_exists()
+    logger.info("Updating CX firmware on all workers")
+    lh = host.LocalHost()
+    nfs = NFS(lh, cc.external_port)
+    iso_url = nfs.host_file("/root/iso/fedora-coreos.iso")
+
+    def helper(h: host.HostWithCX) -> None:
+        def check(result: host.Result) -> None:
+            if result.returncode != 0:
+                logger.info(result)
+                sys.exit(-1)
+
+        h.boot_iso_redfish(iso_url)
+        h.ssh_connect("core")
+        check(h.cx_firmware_upgrade())
+        h.cold_boot()
+
+    executor = ThreadPoolExecutor(max_workers=len(cc.workers))
+    # Assuming all workers have CX that need to update their firmware
+    for e in cc.workers:
+        h = host.HostWithCX(e.node)
+        futures[e.name].result()
+        f = executor.submit(helper, h)
+        futures[e.name] = f
+    logger.info("CX setup complete")

--- a/extraConfigCX.py
+++ b/extraConfigCX.py
@@ -42,7 +42,8 @@ def ExtraConfigCX(cc: ClustersConfig, _: ExtraConfigArgs, futures: Dict[str, Fut
     executor = ThreadPoolExecutor(max_workers=len(cc.workers))
     # Assuming all workers have CX that need to update their firmware
     for e in cc.workers:
-        h = host.HostWithCX(e.node)
+        bmc = host.bmc_from_host_name_or_ip(e.node, e.bmc_ip, e.bmc_user, e.bmc_password)
+        h = host.HostWithCX(e.node, bmc)
         futures[e.name].result()
         f = executor.submit(helper, h)
         futures[e.name] = f

--- a/extraConfigRunner.py
+++ b/extraConfigRunner.py
@@ -6,6 +6,7 @@ from extraConfigOvnK import ExtraConfigOvnK
 from extraConfigCNO import ExtraConfigCNO
 from extraConfigRT import ExtraConfigRT
 from extraConfigDualStack import ExtraConfigDualStack
+from extraConfigCX import ExtraConfigCX
 from clustersConfig import ClustersConfig
 from clustersConfig import ExtraConfigArgs
 from concurrent.futures import Future
@@ -32,6 +33,7 @@ class ExtraConfigRunner:
             "cno": ExtraConfigCNO,
             "rt": ExtraConfigRT,
             "dualstack": ExtraConfigDualStack,
+            "cx_firmware": ExtraConfigCX,
         }
 
     def run(self, to_run: ExtraConfigArgs, futures: Dict[str, Future[None]]) -> None:

--- a/host.py
+++ b/host.py
@@ -481,6 +481,21 @@ class Host:
         return self.run(f"stat {path}", logging.DEBUG).returncode == 0
 
 
+class HostWithCX(Host):
+    def cx_firmware_upgrade(self) -> Result:
+        logger.info("Upgrading CX firmware")
+        return self.run_in_container("/cx_fwup")
+
+    def run_in_container(self, cmd: str, interactive: bool = False) -> Result:
+        name = "cx"
+        setup = f"sudo podman run --pull always --replace --pid host --network host --user 0 --name {name} -dit --privileged -v /dev:/dev quay.io/bnemeth/bf"
+        r = self.run(setup, logging.DEBUG)
+        if r.returncode != 0:
+            return r
+        it = "-it" if interactive else ""
+        return self.run(f"sudo podman exec {it} {name} {cmd}")
+
+
 class HostWithBF2(Host):
     def connect_to_bf(self, bf_addr: str) -> None:
         self.ssh_connect("core")
@@ -538,7 +553,7 @@ class HostWithBF2(Host):
         return self.run_in_container(cmd, True)
 
     def bf_firmware_upgrade(self) -> Result:
-        logger.info("Upgrading firmware")
+        logger.info("Upgrading BF firmware")
         return self.run_in_container("/fwup")
 
     def bf_firmware_defaults(self) -> Result:


### PR DESCRIPTION
This will be used in a new Jenkins job to test the CX card.

- Add `cx_firmware` to `extraConfigRunner.py`
- Add file `extraConfigCX.py`
- Add `class HostWithCX(Host):` in `host.py` in the style of `HostWithBF2`

- depends on PR for cx_fwup in dpu-tools <https://github.com/bn222/dpu-tools/pull/20>