### PR TITLE
Fix error where bos2 is in worker number

### DIFF
--- a/clustersConfig.py
+++ b/clustersConfig.py
@@ -232,7 +232,11 @@ class ClustersConfig:
             self._ensure_clusters_loaded()
             assert self._cluster_info is not None
             name = self._cluster_info.workers[a]
-            return re.sub("[^0-9]", "", name)
+            lab_match = re.search("lab(\d+)", name)
+            if lab_match:
+                return lab_match.group(1)
+            else:
+                return re.sub("[^0-9]", "", name)
 
         def worker_name(a: int) -> str:
             self._ensure_clusters_loaded()


### PR DESCRIPTION
The old regex for extracting the worker number no longer works. For example
`wsfd-advnetlab246.anl.eng.bos2.dc.redhat.com`
Produces worker number of `2462` because of the extra 2 in bos2, instead of `246`

The new regex takes all of the digits after `lab`, or uses the old regex if there is no `lab`.