### PR TITLE
DRAFT: vm on remote hosts installation

### DIFF
--- a/arguments.py
+++ b/arguments.py
@@ -52,6 +52,7 @@ def remove_empty_strings(comma_string: str) -> List[str]:
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description='Cluster deployment automation')
     parser.add_argument('config', metavar='config', type=str, help='Yaml file with config').completer = yaml_completer  # type: ignore
+    parser.add_argument('-u', '--file_verbosity', choices=['debug', 'info', 'warning', 'error', 'critical'], default='debug', help='Set the file logging level (default: debug)')
     parser.add_argument('-v', '--verbosity', choices=['debug', 'info', 'warning', 'error', 'critical'], default='info', help='Set the logging level (default: info)')
     parser.add_argument('--secret', dest='secrets_path', default='', action='store', type=str, help='pull_secret.json path (default is in cwd)')
     parser.add_argument('--assisted-installer-url', dest='url', default='192.168.122.1', action='store', type=str, help='If set to 0.0.0.0 (the default), Assisted Installer will be started locally')
@@ -91,7 +92,7 @@ def parse_args() -> argparse.Namespace:
         args.worker_range = common.RangeList(args.workers)
         args.worker_range.exclude(args.skip_workers)
 
-    configure_logger(getattr(logging, args.verbosity.upper()))
+    configure_logger(getattr(logging, args.verbosity.upper()), getattr(logging, args.file_verbosity.upper()))
 
     if not args.secrets_path:
         args.secrets_path = os.path.join(os.getcwd(), "pull_secret.json")

--- a/clusterDeployer.py
+++ b/clusterDeployer.py
@@ -791,11 +791,19 @@ class ClusterDeployer:
             rh.run(f"chmod a+rw {image_path}")
             iso_src = os.path.join(os.getcwd(), f"{infra_env}.iso")
             iso_path = os.path.join(image_path, f"{infra_env}.iso")
-            logger.info(f"Copying {iso_src} to {rh.hostname()}:/{iso_path}")
-            rh.copy_to(iso_src, iso_path)
+
+            # sftp is very slow => use scp instead (x3 faster)
+            # Do not use mgmt interface for copying (big) file. Use virbr0 as much faster.
+            # We only need to access the remote host through that interface now, so do not consume a new ip address for this
+            # but use an IP configured to use later for a VM.
+            # Using those two tricks (scp and virbr0) copying two files is done in 3 sec instead of a minute.
+            vm = list(x for x in self._cc.workers if x.kind == "vm" and x.node == bm.node)
+            logger.debug(rh.run(f"ip addr add {vm[0].ip}/24 dev virbr0"))
+            logger.info(f"Copying {iso_src} to {vm[0].ip}:/{iso_path}")
+            os.system(f"scp -o StrictHostKeyChecking=no {iso_src} {vm[0].ip}:/{image_path} > /dev/null 2>&1")
+            logger.debug(rh.run(f"ip addr del {vm[0].ip}/24 dev virbr0"))
             logger.debug(f"iso_path is now {iso_path} for {rh.hostname()}")
 
-            vm = list(x for x in self._cc.workers if x.kind == "vm" and x.node == bm.node)
             for e in vm:
                 setup_dhcp_entry(lh, e)
 

--- a/clusterDeployer.py
+++ b/clusterDeployer.py
@@ -83,6 +83,15 @@ def setup_vm(h: host.Host, cfg: NodeConfig, iso_or_image_path: str) -> host.Resu
     name = cfg.name
     mac = cfg.mac
     disk_size_gb = cfg.disk_size
+    cmd = "virsh list --all"
+    ret = h.run(cmd)
+    if f"{name}" in ret.out:
+        logger.info(f"Destroying/Undefining {name} as already existed")
+        cmd = f"virsh destroy {name}"
+        ret = h.run(cmd)
+        cmd = f"virsh undefine {name}"
+        ret = h.run(cmd)
+
     if iso_or_image_path.endswith(".iso"):
         options = "-o preallocation="
         if cfg.is_preallocated():
@@ -117,6 +126,7 @@ def setup_vm(h: host.Host, cfg: NodeConfig, iso_or_image_path: str) -> host.Resu
         --events on_reboot=restart
         {cdrom_line}
         --disk path={cfg.image_path}
+        --check path_in_use=off
         {append}
     """
 

--- a/logger.py
+++ b/logger.py
@@ -1,27 +1,30 @@
 import logging
-from typing import Optional
-from typing import TextIO
 
 
-def configure_logger(lvl: int) -> logging.Logger:
+def configure_logger(stream_lvl: int, file_lvl: int) -> logging.Logger:
     logger = logging.getLogger("CDA")
+    lvl = min(stream_lvl, file_lvl)
     logger.setLevel(lvl)
 
     fmt = "%(asctime)s %(levelname)s: %(message)s"
     datefmt = "%Y-%m-%d %H:%M:%S"
     formatter = logging.Formatter(fmt, datefmt)
 
+    fh = logging.FileHandler("cda-debug.log", mode='w')
+    fh.setLevel(file_lvl)
+    fh.setFormatter(formatter)
+
     handler = logging.StreamHandler()
-    handler.setLevel(lvl)
+    handler.setLevel(stream_lvl)
     handler.setFormatter(formatter)
 
-    global prev_handler
-    if prev_handler is not None:
-        logger.removeHandler(prev_handler)
-    prev_handler = handler
+    if logger.handlers is not None:
+        for h in reversed(logger.handlers):
+            logger.removeHandler(h)
+
     logger.addHandler(handler)
+    logger.addHandler(fh)
     return logger
 
 
-prev_handler: Optional['logging.StreamHandler[TextIO]'] = None
-logger = configure_logger(logging.INFO)
+logger = configure_logger(logging.INFO, logging.DEBUG)


### PR DESCRIPTION
3 small patches improving installation of VMs on remote:
- Overwrite existing VMs with same names. Facilitate installation when something went wrong ...
- Improve speed of copying iso on remote hosts hosting vms by using the 100G interface (expected gain for 40 remote physical hosts: from 20 minutes to less than 2 minutes)
- add by default a DEBUG logger to cda-debug.log