### PR TITLE
Add `get_auto_port` so NFS can work with auto

### DIFF
--- a/clusterDeployer.py
+++ b/clusterDeployer.py
@@ -394,11 +394,7 @@ class ClusterDeployer:
     def _validate_api_port(self, lh: host.Host) -> Optional[str]:
         host_config = self.local_host_config(lh.hostname())
         if host_config.network_api_port == "auto":
-            interfaces = common.carrier_no_addr(lh)
-            if len(interfaces) == 0:
-                return None
-            else:
-                host_config.network_api_port = interfaces[0].ifname
+            host_config.network_api_port = common.get_auto_port(lh)
 
         port = host_config.network_api_port
         logger.info(f'Validating API network port {port}')

--- a/common.py
+++ b/common.py
@@ -129,6 +129,9 @@ def route_to_port(host: host.Host, route: str) -> Optional[str]:
 
 
 def port_to_ip(host: host.Host, port_name: str) -> Optional[str]:
+    if port_name == "auto":
+        port_name = get_auto_port(host)
+
     entries = ipa_to_entries(ipa(host))
     for entry in entries:
         if entry.ifname == port_name:
@@ -145,3 +148,11 @@ def carrier_no_addr(host: host.Host) -> List[IPRouteAddressEntry]:
     entries = ipa_to_entries(ipa(host))
 
     return [x for x in entries if carrier_no_addr(x)]
+
+
+def get_auto_port(host: host.Host) -> str:
+    interfaces = carrier_no_addr(host)
+    if len(interfaces) == 0:
+        raise ValueError("No interfaces found for auto port")
+    else:
+        return interfaces[0].ifname


### PR DESCRIPTION
I was running into an issue in microshift where the port being "auto" gave the error `Failed to get ip when hosting file {file} on nfs`

I took the logic from clusterDeployer, put it in `get_auto_port` and called it from `_validate_api_port` & `port_to_ip`