### PR TITLE
Add support for automatically rebuilding OVN images from upstream source and redeploying OVN-K.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,44 @@ clusters:
 EOF
 ```
 
-## Generate a vm Single Node OpenShift (SNO) cluster configuration file (3)
+## Generate a cluster configuration file that uses OVN rebuilt from source (3)
+```yaml
+cat > cluster.yaml << EOF
+clusters:
+  - name : "vm"
+    api_vip: "192.168.122.99"
+    ingress_ip: "192.168.122.101"
+    kubeconfig: "/root/kubeconfig.vm"
+    masters:
+    - name: "vm-master-1"
+      kind: "vm"
+      node: "localhost"
+      ip: "192.168.122.141"
+    - name: "vm-master-2"
+      kind: "vm"
+      node: "localhost"
+      ip: "192.168.122.142"
+    - name: "vm-master-3"
+      kind: "vm"
+      node: "localhost"
+      ip: "192.168.122.143"
+    workers:
+    - name: "vm-worker-1"
+      kind: "vm"
+      node: "localhost"
+      ip: "192.168.122.144"
+    - name: "vm-worker-2"
+      kind: "vm"
+      node: "localhost"
+      ip: "192.168.122.145"
+    postconfig:
+    - name: "ovn_custom"   # Rebuilds OVN from upstream ovn-org/ovn code.
+    - name: "ovnk8s"       # Rolls out the ovn-k daemonset using the new image.
+      image: "localhost/ovnk-custom-image:dev"
+EOF
+```
+
+## Generate a vm Single Node OpenShift (SNO) cluster configuration file (4)
 ```yaml
 cat > cluster.yaml << EOF
 clusters:

--- a/clustersConfig.py
+++ b/clustersConfig.py
@@ -24,7 +24,13 @@ def random_mac() -> str:
 @dataclass
 class ExtraConfigArgs:
     name: str
+
+    # OVN-K extra configs:
+    # New ovn-k image to use.
     image: Optional[str] = None
+    # Time to wait for new ovn-k to roll out.
+    ovnk_rollout_timeout: str = "20m"
+
     kubeconfig: Optional[str] = None
     mapping: Optional[List[Dict[str, str]]] = None
 

--- a/clustersConfig.py
+++ b/clustersConfig.py
@@ -34,6 +34,10 @@ class ExtraConfigArgs:
     kubeconfig: Optional[str] = None
     mapping: Optional[List[Dict[str, str]]] = None
 
+    # Custom OVN build extra configs:
+    # Time to wait for the builders to roll out.
+    custom_ovn_build_timeout: str = "20m"
+
 
 @dataclass
 class NodeConfig:

--- a/extraConfigCustomOvn.py
+++ b/extraConfigCustomOvn.py
@@ -1,0 +1,32 @@
+from clustersConfig import ClustersConfig
+from k8sClient import K8sClient
+import sys
+from concurrent.futures import Future
+from typing import Dict
+from logger import logger
+from clustersConfig import ExtraConfigArgs
+
+
+def ExtraConfigCustomOvn(cc: ClustersConfig, cfg: ExtraConfigArgs, futures: Dict[str, Future[None]]) -> None:
+    [f.result() for (_, f) in futures.items()]
+    logger.info("Running post config step to build custom OVN from source")
+    iclient = K8sClient(cc.kubeconfig)
+
+    logger.info("Apply custom OVN daemonset")
+    iclient.oc_run_or_die("project openshift-ovn-kubernetes")
+    iclient.oc_run_or_die("create -f manifests/ovn/build_ovn_ds.yaml")
+
+    # Wait for all build pods to become ready (the new image is available
+    # then).
+    iclient.oc_run_or_die(f"rollout status --timeout={cfg.custom_ovn_build_timeout} daemonset/ovn-from-source")
+
+    logger.info("Custom OVN build done, deleting daemonset.")
+    iclient.oc_run_or_die("delete daemonset ovn-from-source")
+
+
+def main() -> None:
+    pass
+
+
+if __name__ == "__main__":
+    main()

--- a/extraConfigRunner.py
+++ b/extraConfigRunner.py
@@ -3,6 +3,7 @@ from extraConfigSriov import ExtraConfigSriov, ExtraConfigSriovOvSHWOL, ExtraCon
 from extraConfigDpuTenant import ExtraConfigDpuTenantMC, ExtraConfigDpuTenant, ExtraConfigDpuTenant_NewAPI
 from extraConfigDpuInfra import ExtraConfigDpuInfra, ExtraConfigDpuInfra_NewAPI
 from extraConfigOvnK import ExtraConfigOvnK
+from extraConfigCustomOvn import ExtraConfigCustomOvn
 from extraConfigCNO import ExtraConfigCNO
 from extraConfigRT import ExtraConfigRT
 from extraConfigDualStack import ExtraConfigDualStack
@@ -30,6 +31,7 @@ class ExtraConfigRunner:
             "dpu_tenant": ExtraConfigDpuTenant,
             "dpu_tenant_new_api": ExtraConfigDpuTenant_NewAPI,
             "ovnk8s": ExtraConfigOvnK,
+            "ovn_custom": ExtraConfigCustomOvn,
             "cno": ExtraConfigCNO,
             "rt": ExtraConfigRT,
             "dualstack": ExtraConfigDualStack,

--- a/k8sClient.py
+++ b/k8sClient.py
@@ -58,9 +58,16 @@ class K8sClient:
                         return str(addr.address)
         return None
 
-    def oc(self, cmd: str) -> host.Result:
+    def oc(self, cmd: str, must_succeed: bool = False) -> host.Result:
         lh = host.LocalHost()
-        return lh.run(f"{self.oc_bin} {cmd} --kubeconfig {self._kc}")
+        cmd = f"{self.oc_bin} {cmd} --kubeconfig {self._kc}"
+        if must_succeed:
+            return lh.run_or_die(cmd)
+        else:
+            return lh.run(cmd)
+
+    def oc_run_or_die(self, cmd: str) -> host.Result:
+        return self.oc(cmd, must_succeed=True)
 
     def ensure_oc_binary(self) -> None:
         lh = host.LocalHost()

--- a/manifests/ovn/build_ovn_ds.yaml
+++ b/manifests/ovn/build_ovn_ds.yaml
@@ -1,0 +1,129 @@
+# WARNING: This is a hack because it mangles the host's containers and
+# images directly from within the pods.
+
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: ovn-from-source
+spec:
+  selector:
+      matchLabels:
+        name: ovn-from-source 
+  template:
+    metadata:
+      labels:
+        name: ovn-from-source 
+    spec:
+      containers:
+      - image: quay.io/fedora/fedora:latest
+        name: idle
+        command:
+            - sleep
+            - infinity
+      initContainers:
+      - image: quay.io/fedora/fedora:latest
+        name: builder
+        securityContext:
+          privileged: true 
+        volumeMounts:
+        - mountPath: /var/lib/containers
+          name: var-lib-containers
+        - mountPath: /var/run/crio
+          name: var-run-crio
+        command:
+            - /bin/bash
+            - -c
+            - |
+              OVN_REPO=${OVN_REPO:-"https://github.com/ovn-org/ovn.git"}
+              OVN_BRANCH=${OVN_BRANCH:-"main"}
+              CRITOOLS_VER=${CRITOOLS_VER:-"v1.29.0"}
+
+              # OVN build dependencies that can be removed to simplify build
+              # on UBI.
+              OVN_REMOVE_DEPS=${OVN_REMOVE_DEPS:-"graphviz groff sphinx-build unbound checkpolicy selinux-policy-devel"}
+
+              DEPS="containernetworking-plugins podman runc wget"
+              sudo dnf install -y $DEPS
+
+              wget https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRITOOLS_VER}/crictl-${CRITOOLS_VER}-linux-amd64.tar.gz
+              sudo tar zxvf crictl-${CRITOOLS_VER}-linux-amd64.tar.gz -C /usr/local/bin
+              rm -f crictl-${CRITOOLS_VER}-linux-amd64.tar.gz
+
+              ovnk_img=$(crictl ps 2> /dev/null | grep ovn-controller | awk '{print $2}')
+              echo "Using ovn-kubernetes base image: ${ovnk_img}"
+
+              if podman images | grep -q 'ovnk-image.*original'; then
+                echo "Original image tag found: 'ovnk-image:original'"
+              else
+                podman tag ${ovnk_img} ovnk-image:original
+                echo "Original image tagged as 'ovnk-image:original'"
+              fi
+
+              cat << EOF > Dockerfile 
+                ARG OVNK_IMAGE
+                FROM \$OVNK_IMAGE
+
+                ARG OVN_REMOVE_DEPS
+                ARG OVN_REPO
+                ARG OVN_BRANCH
+
+                RUN dnf install -y git rpm-build
+
+                WORKDIR /root
+                RUN rm -rf /root/ovn && git clone \${OVN_REPO}
+                WORKDIR /root/ovn
+                RUN git checkout \${OVN_BRANCH}
+                RUN git submodule update --init
+
+                # Remove non-essential dependencies.
+                RUN for dep in \$OVN_REMOVE_DEPS; do \
+                        sed -i "/\$dep/d" rhel/ovn-fedora.spec.in; \
+                    done
+
+                # Install essential dependencies.
+                RUN sed -e 's/@VERSION@/0.0.1/' rhel/ovn-fedora.spec.in > /tmp/ovn.spec
+                RUN dnf builddep -y /tmp/ovn.spec
+
+                # Build RPMS.
+                WORKDIR /root/ovn/ovs
+                RUN ./boot.sh && ./configure && make dist
+
+                WORKDIR /root/ovn
+                RUN ./boot.sh && ./configure && make dist && make rpm-fedora
+
+                # Force upgrade to use custom OVN rpms.
+                RUN rpm -Uhv --nodeps --force /root/ovn/rpm/rpmbuild/RPMS/x86_64/ovn-*rpm
+              EOF
+
+              # To avoid issues with dbus:
+              # https://bugzilla.redhat.com/show_bug.cgi?id=1768954#c4
+              PODMAN_EXTRA_ARGS="--cgroup-manager=cgroupfs"
+              sudo podman ${PODMAN_EXTRA_ARGS} build --net host -t ovnk-custom-image:dev \
+                --build-arg OVNK_IMAGE=${ovnk_img} \
+                --build-arg OVN_REPO=${OVN_REPO} \
+                --build-arg OVN_BRANCH=${OVN_BRANCH} \
+                --build-arg OVN_REMOVE_DEPS="${OVN_REMOVE_DEPS}" \
+                 -f Dockerfile .
+              echo SUCCESS
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+
+      # Mount:
+      # - /var/lib/containers for podman to be able to write images to
+      #   the host directly from inside the pod.
+      # - /var/run/crio for crictl to be able to query containers managed
+      #   by cri-o.
+      volumes:
+      - name: var-lib-containers
+        hostPath:
+          path: /var/lib/containers
+      - name: var-run-crio
+        hostPath:
+          path: /var/run/crio
+
+      terminationGracePeriodSeconds: 10
+      serviceAccountName: ovn-kubernetes-node
+      hostNetwork: true
+      dnsPolicy: Default
+      hostPID: true
+      priorityClassName: "system-node-critical"


### PR DESCRIPTION
The advantage of the new post processing step is that it builds everything in-cluster, without the need of an external image builder or access to OpenShift registries.

Also ensure that the ovn-k extra config properly waits for the new image to be rolled out.