### PR TITLE
Add sriov operator config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ kickstart.ks
 pull_secret.json
 *.tar
 *.iso
+ocp-venv

--- a/extraConfigSriov.py
+++ b/extraConfigSriov.py
@@ -47,6 +47,9 @@ def ExtraConfigSriov(cc: ClustersConfig, cfg: ExtraConfigArgs, futures: Dict[str
 
     logger.info("running make deploy-setup")
     logger.info(lh.run("make deploy-setup", env=env))
+
+    # Future proof for when sriov moves to new switchdev implementation: https://github.com/k8snetworkplumbingwg/sriov-network-operator/blob/master/doc/design/switchdev-refactoring.md
+    client.oc("apply -f manifest/nicmode/sriov-operator-config.yaml")
     time.sleep(60)
     os.chdir(cur_dir)
 

--- a/host.py
+++ b/host.py
@@ -557,7 +557,7 @@ class HostWithBF2(Host):
 
     def bf_firmware_upgrade(self) -> Result:
         logger.info("Upgrading BF firmware")
-        return self.run_in_container("/fwup")
+        return self.run_in_container("/fwup -v 24.39.2048")
 
     def bf_firmware_defaults(self) -> Result:
         logger.info("Setting firmware config to defaults")

--- a/manifests/nicmode/sriov-operator-config.yaml
+++ b/manifests/nicmode/sriov-operator-config.yaml
@@ -1,0 +1,10 @@
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovOperatorConfig
+metadata:
+  name: default
+  namespace: openshift-sriov-network-operator
+spec:
+  enableInjector: true
+  enableOperatorWebhook: true
+  configurationMode: "systemd"
+  logLevel: 2


### PR DESCRIPTION
    With the eventual move to
    https://github.com/k8snetworkplumbingwg/sriov-network-operator/blob/master/doc/design/switchdev-refactoring.md
    we will now need to both:
    
    - Create SriovOperatorConfig (this is done automatically by make deploy)
    - Specify SriovOperatorConfig.configurationMode.
  