### PR TITLE
[th/update-kubernetes-yum-repo] dependencies: use kubernetes community-owned package repositories

### DIFF
--- a/dependencies.sh
+++ b/dependencies.sh
@@ -14,10 +14,11 @@ $PYTHON_CMD -m pip install PyYAML --ignore-installed
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-\$basearch
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.29/rpm/
 enabled=1
 gpgcheck=1
-gpgkey=https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.29/rpm/repodata/repomd.xml.key
+#exclude=kubelet kubeadm kubectl cri-tools kubernetes-cni
 EOF
 
 dnf install -y wget rust coreos-installer kubectl libvirt podman qemu-img qemu-kvm virt-install make git golang-bin virt-viewer osbuild-composer composer-cli cockpit-composer bash-completion firewalld lorax


### PR DESCRIPTION
See [1]:

  On August 15, 2023, the Kubernetes project announced the general
  availability of the community-owned package repositories for Debian and
  RPM packages available at pkgs.k8s.io. The new package repositories are
  replacement for the legacy Google-hosted package repositories:
  apt.kubernetes.io and yum.kubernetes.io.

See also the differences between the Google hosted repository and the new Kubernetes package repository ([3]).

In this case, select Kubernetes version v1.29 ([4])

[1] https://kubernetes.io/blog/2023/08/31/legacy-package-repository-deprecation/
[2] https://kubernetes.io/blog/2023/08/15/pkgs-k8s-io-introduction/
[3] https://kubernetes.io/blog/2023/08/15/pkgs-k8s-io-introduction/#what-are-significant-differences-between-the-google-hosted-and-kubernetes-package-repositories
[4] https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/