### PR TITLE
[th/deprecated-logging-warn] cda: use logger.warning() instead of deprecated warn()

### DIFF
--- a/cda.py
+++ b/cda.py
@@ -21,9 +21,9 @@ def main_deploy(args: argparse.Namespace) -> None:
         # workaround, this will still install 4.14, but AI will think
         # it is 4.13 (see also workaround when setting up versions)
         if cc.version[: len("4.14")] == "4.14":
-            logger.warn("Applying workaround for assisted installer issue")
-            logger.warn("Will pretend to install 4.13, but using 4.14 pullsec")
-            logger.warn("Ignore all output from Assisted that mentions 4.13")
+            logger.warning("Applying workaround for assisted installer issue")
+            logger.warning("Will pretend to install 4.13, but using 4.14 pullsec")
+            logger.warning("Ignore all output from Assisted that mentions 4.13")
             cc.version = "4.13.0-nightly"
     else:
         logger.info(f"Will use Assisted Installer running at {args.url}")

--- a/clustersConfig.py
+++ b/clustersConfig.py
@@ -61,6 +61,7 @@ class NodeConfig:
 
     def __post_init__(self) -> None:
         if self.type:
+            logger.warning("Deprecated 'type' in node config. Use 'kind' instead")
             self.kind = self.type
 
         delattr(self, 'type')


### PR DESCRIPTION
Python's logging.warn() is long deprecated for logging.warning(). See for example [1].

This causes deprecation warnings like
```
  /root/cluster-deployment-automation/cda.py:22: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
    logger.warn("Applying workaround for assisted installer issue")
  2024-03-08 12:11:14 WARNING: Applying workaround for assisted installer issue
```
[1] https://docs.python.org/3/library/logging.html#logging.warning