### PR TITLE
[th/fix-invalid-escape-seq] all: fix invalid escape sequences in strings

### DIFF
--- a/clustersConfig.py
+++ b/clustersConfig.py
@@ -245,7 +245,7 @@ class ClustersConfig:
             self._ensure_clusters_loaded()
             assert self._cluster_info is not None
             name = self._cluster_info.workers[a]
-            lab_match = re.search("lab(\d+)", name)
+            lab_match = re.search(r"lab(\d+)", name)
             if lab_match:
                 return lab_match.group(1)
             else:

--- a/extraConfigDpuInfra.py
+++ b/extraConfigDpuInfra.py
@@ -186,7 +186,7 @@ def ExtraConfigDpuInfra(cc: ClustersConfig, _: ExtraConfigArgs, futures: Dict[st
     client.oc("create -f manifests/infra/dpuclusterconfig.yaml")
 
     logger.info("Patching mcp setting maxUnavailable to 2")
-    client.oc("patch mcp dpu --type=json -p=\[\{\"op\":\"replace\",\"path\":\"/spec/maxUnavailable\",\"value\":2\}\]")
+    client.oc("patch mcp dpu --type=json -p=\\[\\{\"op\":\"replace\",\"path\":\"/spec/maxUnavailable\",\"value\":2\\}\\]")
 
     logger.info("Labeling nodes")
     for b in bf_names:
@@ -263,7 +263,7 @@ def ExtraConfigDpuInfra_NewAPI(cc: ClustersConfig, _: ExtraConfigArgs, futures: 
     client.oc("create -f manifests/infra/dpuclusterconfig.yaml")
 
     logger.info("Patching mcp setting maxUnavailable to 2")
-    client.oc("patch mcp dpu --type=json -p=\[\{\"op\":\"replace\",\"path\":\"/spec/maxUnavailable\",\"value\":2\}\]")
+    client.oc("patch mcp dpu --type=json -p=\\[\\{\"op\":\"replace\",\"path\":\"/spec/maxUnavailable\",\"value\":2\\}\\]")
 
     logger.info("Labeling nodes")
     for b in bf_names:

--- a/extraConfigDpuTenant.py
+++ b/extraConfigDpuTenant.py
@@ -31,7 +31,7 @@ def ExtraConfigDpuTenantMC(cc: ClustersConfig, _: ExtraConfigArgs, futures: Dict
     tclient.wait_for_mcp("dpu-host", "dputenantmachineconfig.yaml")
 
     logger.info("Patching mcp setting maxUnavailable to 2")
-    tclient.oc("patch mcp dpu-host --type=json -p=\[\{\"op\":\"replace\",\"path\":\"/spec/maxUnavailable\",\"value\":2\}\]")
+    tclient.oc("patch mcp dpu-host --type=json -p=\\[\\{\"op\":\"replace\",\"path\":\"/spec/maxUnavailable\",\"value\":2\\}\\]")
 
     logger.info("Labeling nodes")
     for e in cc.workers:
@@ -152,7 +152,7 @@ def ExtraConfigDpuTenant(cc: ClustersConfig, cfg: ExtraConfigArgs, futures: Dict
 
     for bfmap in cfg.mapping:
         a: Dict[str, str] = {}
-        mp = re.sub('np\d$', '', bf_port)
+        mp = re.sub(r'np\d$', '', bf_port)
         a["OVNKUBE_NODE_MGMT_PORT_NETDEV"] = f"{mp}v0"
         contents += f"  {bfmap['worker']}: |\n"
         for k, v in a.items():


### PR DESCRIPTION
We can see warnings about this:
```
  $ mypy --strict cda.py --config-file mypy.ini
  /Host/data/src/cluster-deployment-automation/clustersConfig.py:248: SyntaxWarning: invalid escape sequence d
    lab_match = re.search("lab(\d+)", name)
  /Host/data/src/cluster-deployment-automation/extraConfigDpuInfra.py:189: SyntaxWarning: invalid escape sequence [
    client.oc("patch mcp dpu --type=json -p=\[\{\"op\":\"replace\",\"path\":\"/spec/maxUnavailable\",\"value\":2\}\]")
  /Host/data/src/cluster-deployment-automation/extraConfigDpuInfra.py:266: SyntaxWarning: invalid escape sequence [
    client.oc("patch mcp dpu --type=json -p=\[\{\"op\":\"replace\",\"path\":\"/spec/maxUnavailable\",\"value\":2\}\]")
  /Host/data/src/cluster-deployment-automation/extraConfigDpuTenant.py:34: SyntaxWarning: invalid escape sequence [
    tclient.oc("patch mcp dpu-host --type=json -p=\[\{\"op\":\"replace\",\"path\":\"/spec/maxUnavailable\",\"value\":2\}\]")
  /Host/data/src/cluster-deployment-automation/extraConfigDpuTenant.py:155: SyntaxWarning: invalid escape sequence d
    mp = re.sub(npd, , bf_port)
```