### PR TITLE
[th/readme-install] README: update steps in documentation how to install

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,7 @@ steps assume a RHEL/Fedora based distribution is used.  Also, the
 instructions below make the assumption that everything is run as root
 from the repository root directory.
 
-## Generate a ssh key
-NOTE: starting with Fedora 33 RSA keys are considered not secure enough; use
-ed25519 instead.
-
-```bash
-ssh-keygen -t ed25519 -a 64 -N '' -f ~/.ssh/id_ed25519
-```
-
-## Install required software and Python packages by starting a Python virtual environment
+## Install Software and Python Packages, Start a Python Virtual Environment and Setup
 NOTE: Requires Python3.11 or higher
 ```bash
 dnf install -y python3.11
@@ -22,6 +14,9 @@ source ocp-venv/bin/activate
 ./dependencies.sh
 systemctl enable --now libvirtd
 usermod -a -G root qemu
+
+# Ensure having a suitable SSH key
+[ -f ~/.ssh/id_ed25519 ] || ssh-keygen -t ed25519 -N '' -f ~/.ssh/id_ed25519
 ```
 
 ## Activate and deactivate Python virtual environment

--- a/README.md
+++ b/README.md
@@ -14,12 +14,13 @@ ssh-keygen -t ed25519 -a 64 -N '' -f ~/.ssh/id_ed25519
 ```
 
 ## Install required software and Python packages by starting a Python virtual environment
-NOTE: Requires Python3.11 or higher (run `dnf install -y python3.11`)
+NOTE: Requires Python3.11 or higher
 ```bash
+dnf install -y python3.11
 python3.11 -m venv ocp-venv
 source ocp-venv/bin/activate
 ./dependencies.sh
-systemctl enable libvirtd
+systemctl enable --now libvirtd
 usermod -a -G root qemu
 ```
 


### PR DESCRIPTION
It's useful to have the complete steps listed, so they can be conveniently
copy and pasted.
    
- include the installation of python3.11 in the installation steps.
- use `systemctl enable --now libvirtd`, because after a fresh install the
  daemon is not yet running (and we probably want that).
