### PR TITLE
[th/cda-executable] cda: make "cda.py" script executable

### DIFF
--- a/cda.py
+++ b/cda.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # PYTHON_ARGCOMPLETE_OK
 from assistedInstaller import AssistedClientAutomation
 from assistedInstallerService import AssistedInstallerService


### PR DESCRIPTION
Set the executable bit for "cda.py" and add a shebang. It's more convenient to use. It also makes it clear, that this is an executable.