### PR TITLE
[th/flake8-check] adjust github actions and run flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,6 +2,6 @@
 extend-ignore =
     E501
 extend-exclude =
-    *-venv/
+    *venv/
 filename =
     *.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,9 +31,13 @@ jobs:
         python -m pip install types-requests
     - name: black
       run: |
+        black --version
         black --check --diff .
     - name: flake8
       run: |
+        flake8 --version
         flake8
     - name: mypy
-      run: mypy --strict --config-file mypy.ini .
+      run: |
+        mypy --version
+        mypy --strict --config-file mypy.ini .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,7 @@ name: Check Style
 
 on:
   push:
-    branches: [ main ]
   pull_request:
-    branches: [ main ]
 
 jobs:
   lint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,4 +35,4 @@ jobs:
       run: |
         flake8
     - name: mypy
-      run: mypy --strict cda.py --config-file mypy.ini
+      run: mypy --strict --config-file mypy.ini .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,9 +24,13 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install black==22.12.0
+        python -m pip install flake8
     - name: Black
       run: |
         black --check --diff .
+    - name: flake8
+      run: |
+        flake8
 
   mypy:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install black==22.12.0
         python -m pip install flake8
+        python -m pip install flake8-comprehensions
         python -m pip install --upgrade pip
         python -m pip install mypy
         python -m pip install types-paramiko

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,28 +23,16 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install black==22.12.0
         python -m pip install flake8
-    - name: Black
-      run: |
-        black --check --diff .
-    - name: flake8
-      run: |
-        flake8
-
-  mypy:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python
-      uses: actions/setup-python@v3
-      with:
-        python-version: '3.11'
-    - name: Install dependencies
-      run: |
         python -m pip install --upgrade pip
         python -m pip install mypy
         python -m pip install types-paramiko
         python -m pip install types-PyYAML
         python -m pip install types-requests
-    - name: Run mypy
+    - name: black
+      run: |
+        black --check --diff .
+    - name: flake8
+      run: |
+        flake8
+    - name: mypy
       run: mypy --strict cda.py --config-file mypy.ini

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v3

--- a/clusterDeployer.py
+++ b/clusterDeployer.py
@@ -455,7 +455,7 @@ class ClusterDeployer:
         lh.run(f"nmcli device set {api_network} managed no")
 
     def need_external_network(self) -> bool:
-        vm_bm = list(x for x in self._cc.workers if x.kind == "vm" and x.node != "localhost")
+        vm_bm = [x for x in self._cc.workers if x.kind == "vm" and x.node != "localhost"]
         remote_workers = len(self._cc.workers) - len(self._cc.worker_vms())
         remote_masters = len(self._cc.masters) - len(self._cc.master_vms())
         if "workers" not in self.steps:
@@ -692,7 +692,7 @@ class ClusterDeployer:
         executor = ThreadPoolExecutor(max_workers=len(nodes))
         futures = []
 
-        nodes = list(x for x in nodes if x.kind == "physical")
+        nodes = [x for x in nodes if x.kind == "physical"]
         cluster_name = self._cc.name
         infra_env_name = f"{cluster_name}-x86"
         for h in nodes:
@@ -780,7 +780,7 @@ class ClusterDeployer:
             rh.copy_to(iso_src, iso_path)
             logger.debug(f"iso_path is now {iso_path} for {rh.hostname()}")
 
-            vm = list(x for x in self._cc.workers if x.kind == "vm" and x.node == bm.node)
+            vm = [x for x in self._cc.workers if x.kind == "vm" and x.node == bm.node]
             for e in vm:
                 setup_dhcp_entry(lh, e)
 
@@ -884,7 +884,7 @@ class ClusterDeployer:
                     continue
                 nics = json.loads(h["inventory"]).get("interfaces")
                 addresses: List[str] = sum((nic["ipv4_addresses"] for nic in nics), [])
-                stripped_addresses = list(a.split("/")[0] for a in addresses)
+                stripped_addresses = [a.split("/")[0] for a in addresses]
 
                 if w.ip in stripped_addresses:
                     self._ai.update_host(h["id"], {"name": w.name})
@@ -1061,7 +1061,7 @@ class ClusterDeployer:
     def wait_for_workers(self) -> None:
         logger.info(f'waiting for {len(self._cc.workers)} workers')
         lh = host.LocalHost()
-        bf_workers = list(x for x in self._cc.workers if x.kind == "bf")
+        bf_workers = [x for x in self._cc.workers if x.kind == "bf"]
         connections: Dict[str, host.Host] = {}
         while True:
             workers = [w.name for w in self._cc.workers]

--- a/clustersConfig.py
+++ b/clustersConfig.py
@@ -245,7 +245,7 @@ class ClustersConfig:
             self._ensure_clusters_loaded()
             assert self._cluster_info is not None
             name = self._cluster_info.workers[a]
-            lab_match = re.search("lab(\d+)", name)
+            lab_match = re.search(r"lab(\d+)", name)
             if lab_match:
                 return lab_match.group(1)
             else:

--- a/clustersConfig.py
+++ b/clustersConfig.py
@@ -181,7 +181,7 @@ class ClustersConfig:
             self.workers.append(NodeConfig(self.name, **w))
 
         # creates hosts entries for each referenced node name
-        node_names = set(x["name"] for x in cc["hosts"])
+        node_names = {x["name"] for x in cc["hosts"]}
         for node in self.all_nodes():
             if node.kind != "physical" and node.node not in node_names:
                 cc["hosts"].append({"name": node.node})

--- a/extraConfigDpuInfra.py
+++ b/extraConfigDpuInfra.py
@@ -186,7 +186,7 @@ def ExtraConfigDpuInfra(cc: ClustersConfig, _: ExtraConfigArgs, futures: Dict[st
     client.oc("create -f manifests/infra/dpuclusterconfig.yaml")
 
     logger.info("Patching mcp setting maxUnavailable to 2")
-    client.oc("patch mcp dpu --type=json -p=\[\{\"op\":\"replace\",\"path\":\"/spec/maxUnavailable\",\"value\":2\}\]")
+    client.oc("patch mcp dpu --type=json -p=\\[\\{\"op\":\"replace\",\"path\":\"/spec/maxUnavailable\",\"value\":2\\}\\]")
 
     logger.info("Labeling nodes")
     for b in bf_names:
@@ -263,7 +263,7 @@ def ExtraConfigDpuInfra_NewAPI(cc: ClustersConfig, _: ExtraConfigArgs, futures: 
     client.oc("create -f manifests/infra/dpuclusterconfig.yaml")
 
     logger.info("Patching mcp setting maxUnavailable to 2")
-    client.oc("patch mcp dpu --type=json -p=\[\{\"op\":\"replace\",\"path\":\"/spec/maxUnavailable\",\"value\":2\}\]")
+    client.oc("patch mcp dpu --type=json -p=\\[\\{\"op\":\"replace\",\"path\":\"/spec/maxUnavailable\",\"value\":2\\}\\]")
 
     logger.info("Labeling nodes")
     for b in bf_names:

--- a/extraConfigDpuInfra.py
+++ b/extraConfigDpuInfra.py
@@ -83,7 +83,7 @@ def install_custom_kernel(lh: host.Host, client: K8sClient, bf_names: List[str],
         for h in ips:
             futures.append(executor.submit(install_remotely, h, links))
 
-        results = list(f.result() for f in futures)
+        results = [f.result() for f in futures]
         if not all(results):
             logger.info(f"failed, retried {retry} times uptill now")
             logger.info(results)

--- a/extraConfigDpuTenant.py
+++ b/extraConfigDpuTenant.py
@@ -29,7 +29,7 @@ def ExtraConfigDpuTenantMC(cc: ClustersConfig, _: ExtraConfigArgs, futures: Dict
     tclient.wait_for_mcp("dpu-host", "dputenantmachineconfig.yaml")
 
     logger.info("Patching mcp setting maxUnavailable to 2")
-    tclient.oc("patch mcp dpu-host --type=json -p=\[\{\"op\":\"replace\",\"path\":\"/spec/maxUnavailable\",\"value\":2\}\]")
+    tclient.oc("patch mcp dpu-host --type=json -p=\\[\\{\"op\":\"replace\",\"path\":\"/spec/maxUnavailable\",\"value\":2\\}\\]")
 
     logger.info("Labeling nodes")
     for e in cc.workers:
@@ -150,7 +150,7 @@ def ExtraConfigDpuTenant(cc: ClustersConfig, cfg: ExtraConfigArgs, futures: Dict
 
     for bfmap in cfg.mapping:
         a: Dict[str, str] = {}
-        mp = re.sub('np\d$', '', bf_port)
+        mp = re.sub(r'np\d$', '', bf_port)
         a["OVNKUBE_NODE_MGMT_PORT_NETDEV"] = f"{mp}v0"
         contents += f"  {bfmap['worker']}: |\n"
         for k, v in a.items():


### PR DESCRIPTION
- github: print version of used linters
- flake8: enable flake8-comprehensions check
- github: run mypy check against entire directory
- github: run "mypy" check in lint job
- github: don't run lint test with Python 3.9,3.10
- github: run workflows on all branches/pull-requests
- github: run flake8 linter in github actions
- flake8: adjust exclude pattern in config file
- all: fix invalid escape sequences in strings


This also includes #124, because the flake8 check also flags the invalid escape sequences, and the branch wouldn't pass CI, without that patch. Abandon #124 and let it be handled here.