### PR TITLE
Add sriov install from subscription instead of quay

### DIFF
--- a/extraConfigRunner.py
+++ b/extraConfigRunner.py
@@ -1,5 +1,5 @@
 from extraConfigBFB import ExtraConfigBFB, ExtraConfigSwitchNicMode
-from extraConfigSriov import ExtraConfigSriov, ExtraConfigSriovOvSHWOL, ExtraConfigSriovOvSHWOL_NewAPI
+from extraConfigSriov import ExtraConfigSriov, ExtraConfigSriovSubscription, ExtraConfigSriovOvSHWOL, ExtraConfigSriovOvSHWOL_NewAPI
 from extraConfigDpuTenant import ExtraConfigDpuTenantMC, ExtraConfigDpuTenant, ExtraConfigDpuTenant_NewAPI
 from extraConfigDpuInfra import ExtraConfigDpuInfra, ExtraConfigDpuInfra_NewAPI
 from extraConfigOvnK import ExtraConfigOvnK
@@ -23,6 +23,7 @@ class ExtraConfigRunner:
             "bf_bfb_image": ExtraConfigBFB,
             "switch_to_nic_mode": ExtraConfigSwitchNicMode,
             "sriov_network_operator": ExtraConfigSriov,
+            "sriov_network_operator_subscription": ExtraConfigSriovSubscription,
             "sriov_ovs_hwol": ExtraConfigSriovOvSHWOL,
             "sriov_ovs_hwol_new_api": ExtraConfigSriovOvSHWOL_NewAPI,
             "dpu_infra": ExtraConfigDpuInfra,

--- a/manifests/nicmode/sriov-namespace-config.yaml
+++ b/manifests/nicmode/sriov-namespace-config.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-sriov-network-operator
+  annotations:
+    workload.openshift.io/allowed: management

--- a/manifests/nicmode/sriov-operator-group.yaml
+++ b/manifests/nicmode/sriov-operator-group.yaml
@@ -1,0 +1,8 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: sriov-network-operators
+  namespace: openshift-sriov-network-operator
+spec:
+  targetNamespaces:
+  - openshift-sriov-network-operator

--- a/manifests/nicmode/sriov-subscription.yaml
+++ b/manifests/nicmode/sriov-subscription.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: sriov-network-operator-subscription
+  namespace: openshift-sriov-network-operator
+spec:
+  channel: stable
+  name: sriov-network-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace


### PR DESCRIPTION
There was an issue where the CI wasn't building sr-iov to quay, which `make deploy` gets sr-iov from. This broke some sr-iov deployments.  
This commit adds the option to install sr-iov from a subscription.

- Add ExtraConfigSriovSubscription following the [ocp directions](https://docs.openshift.com/container-platform/4.15/networking/hardware_networks/installing-sriov-operator.html)
- Add `check_sriov_installed` to confirm sr iov is installed 