### PR TITLE
[th/coreos-build-rootful] coreosBuilder: fix rootful coreos build via podman

### DIFF
--- a/coreosBuilder.py
+++ b/coreosBuilder.py
@@ -192,8 +192,7 @@ class CoreosBuilder:
             logger.info(f"Writing ignition to {ign}")
             f.write(ign)
 
-        if os.path.exists(dst):
-            os.remove(dst)
+        os.makedirs(os.path.dirname(dst), exist_ok=True)
 
         cmd = f"coreos-installer iso ignition embed -i {fn_ign} -o {dst} {embed_src}"
         lh = host.LocalHost()

--- a/coreosBuilder.py
+++ b/coreosBuilder.py
@@ -135,10 +135,8 @@ class CoreosBuilder:
         cur_dir = os.getcwd()
         os.chdir(fcos_dir)
 
-        # -e COSA_NO_KVM=1 \
         cmd = f"""
-        podman run --rm -ti --security-opt label=disable --privileged         \
-               --uidmap=1000:0:1 --uidmap=0:1:1000 --uidmap 1001:1001:64536   \
+        podman run --rm -ti --userns=host -u root --privileged                \
                -v {fcos_dir}:/srv/ --device /dev/kvm --device /dev/fuse       \
                --tmpfs /tmp -v /var/tmp:/var/tmp --name cosa                  \
                -v {config_dir}:/git:ro                                        \


### PR DESCRIPTION
The previous podman command does not seem correct. It follows the documentation [1], but note that the doc says:

>  Note: You should run this command as non-root
>  It's also fully supported to use podman as root, but some of the
>  arguments here need to change for that.

But then, the command line was as if we were to run the container rootless. Note that /tmp/build/fcos is owned by root, as it is created by CDA.

Consequently, there is a failure:
```
# podman run --rm -ti --security-opt label=disable --privileged --uidmap=1000:0:1 --uidmap=0:1:1000 --uidmap 1001:1001:64536 -v /tmp/build/fcos:/srv/ --device /dev/kvm --device /dev/fuse --tmpfs /tmp -v /var/tmp:/var/tmp --name cosa -v /tmp/build/fedora-coreos-config:/git:ro quay.io/coreos-assembler/coreos-assembler:latest fetch
rm: cannot remove '/dev/kvm': Device or resource busy
failed to execute cmd-fetch: exit status 1
```
It seems to be because /dev/kvm is bind mounted inside the container. As such, it cannot be removed and [2] fatally fails.

It's unclear how the previous command was ever working. It must work in some cases, but it doesn't work for me. Note there was also a comment "-e COSA_NO_KVM=1", which would workaround the problem differently and bypass the code in [2].

Instead, run the podman container as root and don't map users.

[1] https://github.com/coreos/coreos-assembler/blob/48414b32cb10351921b14471e1a02d29fb04fc7b/docs/building-fcos.md#define-a-bash-alias-to-run-cosa
[2] https://github.com/coreos/coreos-assembler/blob/d833492aa7dfe75c05ce207b222d8978b173c745/src/cmdlib.sh#L116