### PR TITLE
[th/kubeadmin-password] assistedInstaller: download kubeadmin-password together with kubeconfig

### DIFF
--- a/clusterDeployer.py
+++ b/clusterDeployer.py
@@ -154,8 +154,7 @@ class ClusterDeployer:
         for h in self._all_hosts:
             h.ensure_not_linked_to_network()
 
-        if os.path.exists(self._cc.kubeconfig):
-            os.remove(self._cc.kubeconfig)
+        AssistedClientAutomation.delete_kubeconfig_and_secrets(self._cc.name, self._cc.kubeconfig)
 
     def _preconfig(self) -> None:
         for e in self._cc.preconfig:
@@ -331,8 +330,7 @@ class ClusterDeployer:
         self._wait_known_state(names, cb)
         self._ai.start_until_success(cluster_name)
 
-        logger.info(f'downloading kubeconfig to {self._cc.kubeconfig}')
-        self._ai.download_kubeconfig(self._cc.name, self._cc.kubeconfig)
+        self._ai.download_kubeconfig_and_secrets(self._cc.name, self._cc.kubeconfig)
 
         self._ai.wait_cluster(cluster_name)
 

--- a/clusterSnapshotter.py
+++ b/clusterSnapshotter.py
@@ -122,7 +122,7 @@ class ClusterSnapshotter:
         for x in futures:
             x.result()
 
-        self._ai.download_kubeconfig(self._cc.name, self._cc.kubeconfig)
+        self._ai.download_kubeconfig_and_secrets(self._cc.name, self._cc.kubeconfig)
 
     def _export_vm(self, config: NodeConfig) -> None:
         lh = host.LocalHost()

--- a/common.py
+++ b/common.py
@@ -179,3 +179,24 @@ def iterate_ssh_keys() -> Iterator[tuple[str, str, str]]:
             pub_key_content = f.read().strip()
             priv_key_file = os.path.splitext(pub_file)[0]
             yield pub_file, pub_key_content, priv_key_file
+
+
+def kubeconfig_get_paths(cluster_name: str, kubeconfig_path: Optional[str]) -> tuple[str, str, str, str]:
+    # AssistedClient.download_kubeconfig() downloads the kubeconfig at a
+    # particular place, determined by the @cluster_name and @kubeconfig_path.
+    #
+    # This function calculates the resulting file names where we can find these
+    # files.
+    if kubeconfig_path:
+        kubeconfig_path = os.path.abspath(kubeconfig_path)
+        path = os.path.dirname(kubeconfig_path)
+    else:
+        path = os.path.abspath(os.getcwd())
+
+    downloaded_kubeadminpassword_path = f"{path}/kubeadmin-password.{cluster_name}"
+    downloaded_kubeconfig_path = f"{path}/kubeconfig.{cluster_name}"
+
+    if not kubeconfig_path:
+        kubeconfig_path = downloaded_kubeconfig_path
+
+    return path, kubeconfig_path, downloaded_kubeconfig_path, downloaded_kubeadminpassword_path


### PR DESCRIPTION
The kubeadmin secret is useful. With it we can `oc login` and get a token with `oc whoami -t`. I think from the X.509 certificate we cannot get a comparable token.

Note that there is a change in behavior here. AssistedInstaller's download_kubeconfig() does not allow to fully specify the file name. It only allows to specify the path, and the file name is always f"{path}/kubeconfig.{name}".  This means, previously the file name of self._cc.kubeconfig was not honored. Now, if the file name differs, we rename the file so that it matches what was requested.

On the other hand, the resulting kubeadmin password is always in the file f"{path}/kubeadmin-password.{name}". The user cannot affect that via configuration.