### PR TITLE
Add ebtables rules to drop unexpected DHCP replies.

### DIFF
--- a/clusterDeployer.py
+++ b/clusterDeployer.py
@@ -351,7 +351,7 @@ class ClusterDeployer:
         # NOTE: this must happen after the masters are installed by AI
         # to ensure AI doesn't detect other nodes on the network.
         for h in hosts_with_masters:
-            h.ensure_linked_to_network()
+            h.ensure_linked_to_network(self._local_host.bridge)
 
         logger.info("Setting password to for root to redhat")
         for h in hosts_with_masters:
@@ -388,7 +388,7 @@ class ClusterDeployer:
         for h in hosts_with_workers:
             h.configure_bridge()
             h.configure_worker_dhcp_entries(self._local_host.bridge)
-            h.ensure_linked_to_network()
+            h.ensure_linked_to_network(self._local_host.bridge)
 
         executor = ThreadPoolExecutor(max_workers=len(self._cc.workers))
 

--- a/clustersConfig.py
+++ b/clustersConfig.py
@@ -108,7 +108,6 @@ class HostConfig:
 
 @dataclass
 class BridgeConfig:
-    api_network: str
     ip: str
     mask: str
     dynamic_ip_range: Optional[Tuple[str, str]] = None
@@ -214,8 +213,8 @@ class ClustersConfig:
             logger.error_and_exit("The supplied cluster_ip_range config is too small for the number of nodes")
 
         dynamic_ip_range = common.ip_range(self.cluster_ip_range[1], common.ip_range_size(ip_range) - n_nodes)
-        self.local_bridge_config = BridgeConfig(api_network=self.network_api_port, ip=self.cluster_ip_range[0], mask=cluster_ip_mask, dynamic_ip_range=dynamic_ip_range)
-        self.remote_bridge_config = BridgeConfig(api_network=self.network_api_port, ip=ip_range[1], mask=cluster_ip_mask)
+        self.local_bridge_config = BridgeConfig(ip=self.cluster_ip_range[0], mask=cluster_ip_mask, dynamic_ip_range=dynamic_ip_range)
+        self.remote_bridge_config = BridgeConfig(ip=ip_range[1], mask=cluster_ip_mask)
 
         # creates hosts entries for each referenced node name
         node_names = {x["name"] for x in cc["hosts"]}

--- a/common.py
+++ b/common.py
@@ -65,6 +65,7 @@ class IPRouteAddressEntry:
     ifname: str
     flags: List[str]
     master: Optional[str]
+    address: str  # Ethernet address.
     addr_info: List[IPRouteAddressInfoEntry]
 
 
@@ -82,7 +83,7 @@ def ipa_to_entries(input: str) -> List[IPRouteAddressEntry]:
 
         master = e["master"] if "master" in e else None
 
-        ret.append(IPRouteAddressEntry(e["ifindex"], e["ifname"], e["flags"], master, addr_infos))
+        ret.append(IPRouteAddressEntry(e["ifindex"], e["ifname"], e["flags"], master, e["address"], addr_infos))
     return ret
 
 

--- a/virtualBridge.py
+++ b/virtualBridge.py
@@ -5,6 +5,7 @@ import time
 from logger import logger
 from typing import Optional, Tuple
 
+import common
 import host
 from clustersConfig import BridgeConfig, NodeConfig
 
@@ -169,3 +170,17 @@ class VirBridge:
             # Not sure why/whether this is needed. But we saw failures w/o it.
             # We need to investigate how to remove the sleep to speed up
             time.sleep(5)
+
+    def eth_address(self) -> str:
+        max_tries = 3
+        logger.info(f"Will try {max_tries} to get the virbr0 ethernet address on {self.hostconn.hostname()}")
+
+        for i in range(max_tries):
+            logger.debug(f"Trying to get the virbr0 ethernet address on {self.hostconn.hostname()} (try #{i})")
+            bridge_port = common.find_port(self.hostconn, 'virbr0')
+            if bridge_port is not None:
+                return bridge_port.address
+            time.sleep(5)
+
+        logger.error_and_exit(f"Failed to get the virbr0 ethernet address on {self.hostconn.hostname()}")
+        return ""


### PR DESCRIPTION
This allows multiple concurrent CDA deployments on the same VLAN.