### PR TITLE
Log while waiting for workers to be ready.

### DIFF
--- a/assistedInstaller.py
+++ b/assistedInstaller.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+import itertools
 import time
 import os
 import json
@@ -99,10 +100,8 @@ class AssistedClientAutomation(AssistedClient):  # type: ignore
     def start_until_success(self, cluster_name: str) -> None:
         self.wait_cluster_ready(cluster_name)
         logger.info(f"Starting cluster {cluster_name} (will retry until success)")
-        tries = 0
-        while True:
+        for tries in itertools.count(0):
             try:
-                tries += 1
                 self.start_cluster(cluster_name)
             except Exception:
                 pass

--- a/clusterDeployer.py
+++ b/clusterDeployer.py
@@ -484,14 +484,14 @@ class ClusterDeployer:
 
         logger.info("Connectivity established to all workers, renaming them in Assisted installer")
         logger.info(f"looking for workers with ip {[w.ip() for w in workers]}")
-        while True:
+        for try_count in itertools.count(0):
             renamed = self._try_rename_workers(infra_env)
             expected = len(workers)
             if renamed == expected:
                 logger.info(f"Found and renamed {renamed} workers")
                 break
             if renamed:
-                logger.info(f"Found and renamed {renamed} workers, but waiting for {expected}, retrying")
+                logger.info(f"Found and renamed {renamed} workers, but waiting for {expected}, retrying (try #{try_count})")
                 time.sleep(5)
 
     def _try_rename_workers(self, infra_env: str) -> int:

--- a/clusterHost.py
+++ b/clusterHost.py
@@ -1,3 +1,4 @@
+import itertools
 import os
 import time
 from concurrent.futures import Future, ThreadPoolExecutor
@@ -187,9 +188,7 @@ class ClusterHost:
         if not nodes:
             return
 
-        try_count = 0
-        while True:
-            try_count += 1
+        for try_count in itertools.count(0):
             states = {node.config.name: node.has_booted() for node in nodes}
             node_names = ', '.join(states.keys())
             logger.info(f"Waiting for nodes ({node_names}) to have booted (try #{try_count})..")
@@ -199,9 +198,7 @@ class ClusterHost:
             time.sleep(10)
         logger.info(f"It took {try_count} tries to wait for nodes ({node_names}) to have booted.")
 
-        try_count = 0
-        while True:
-            try_count += 1
+        for try_count in itertools.count(0):
             states = {node.config.name: node.post_boot(desired_ip_range) for node in nodes}
             node_names = ', '.join(states.keys())
             logger.info(f"Waiting for nodes ({node_names}) to have run post_boot (try #{try_count})..")


### PR DESCRIPTION
When provisioning large numbers of workers at a time this can take long. Logging helps.

The second commit unifies the style of most of the remaining infinite loops trying to avoid boilerplate code.