### PR TITLE
[th/dependencies-fail-on-error] dependencies: abort script on error

### DIFF
--- a/dependencies.sh
+++ b/dependencies.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 if [ "$(which python)" = "$(pwd)/ocp-venv/bin/python" ]; then
     PYTHON_CMD="python"
 else


### PR DESCRIPTION
Don't silently ignore errors in dependencies script.

---

This patch is from #131. It is not OK to ignore errors, it hides real problems. For example, when b75101b55353e06a317818d7defe26dbc41094e0 was necessary, the script encountered an error but did not make it obvious. It takes time to notice that the dependencies were not properly installed.