### PR TITLE
Require a physical port (network_api_port) only if needed.

### DIFF
--- a/assistedInstaller.py
+++ b/assistedInstaller.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+import itertools
 import time
 import os
 import json
@@ -99,10 +100,8 @@ class AssistedClientAutomation(AssistedClient):  # type: ignore
     def start_until_success(self, cluster_name: str) -> None:
         self.wait_cluster_ready(cluster_name)
         logger.info(f"Starting cluster {cluster_name} (will retry until success)")
-        tries = 0
-        while True:
+        for tries in itertools.count(0):
             try:
-                tries += 1
                 self.start_cluster(cluster_name)
             except Exception:
                 pass

--- a/clusterDeployer.py
+++ b/clusterDeployer.py
@@ -51,9 +51,8 @@ class ClusterDeployer:
 
         lh = host.LocalHost()
         lh_config = list(filter(lambda hc: hc.name == lh.hostname(), self._cc.hosts))[0]
-        serves_dhcp = cc.kind == "openshift" and len(cc.local_vms()) != len(cc.all_nodes())
-        self._local_host = ClusterHost(lh, lh_config, cc, cc.local_bridge_config, serves_dhcp=serves_dhcp)
-        self._remote_hosts = {bm.name: ClusterHost(host.RemoteHost(bm.name), bm, cc, cc.remote_bridge_config, serves_dhcp=False) for bm in self._cc.hosts if bm.name != lh.hostname()}
+        self._local_host = ClusterHost(lh, lh_config, cc, cc.local_bridge_config)
+        self._remote_hosts = {bm.name: ClusterHost(host.RemoteHost(bm.name), bm, cc, cc.remote_bridge_config) for bm in self._cc.hosts if bm.name != lh.hostname()}
         self._all_hosts = [self._local_host] + list(self._remote_hosts.values())
         self._futures = {k8s_node.config.name: k8s_node.future for h in self._all_hosts for k8s_node in h._k8s_nodes()}
         self._all_nodes = {k8s_node.config.name: k8s_node for h in self._all_hosts for k8s_node in h._k8s_nodes()}

--- a/clusterHost.py
+++ b/clusterHost.py
@@ -1,3 +1,4 @@
+import itertools
 import os
 import time
 from concurrent.futures import Future, ThreadPoolExecutor
@@ -186,9 +187,7 @@ class ClusterHost:
         if not nodes:
             return
 
-        try_count = 0
-        while True:
-            try_count += 1
+        for try_count in itertools.count(0):
             states = {node.config.name: node.has_booted() for node in nodes}
             node_names = ', '.join(states.keys())
             logger.info(f"Waiting for nodes ({node_names}) to have booted (try #{try_count})..")
@@ -198,9 +197,7 @@ class ClusterHost:
             time.sleep(10)
         logger.info(f"It took {try_count} tries to wait for nodes ({node_names}) to have booted.")
 
-        try_count = 0
-        while True:
-            try_count += 1
+        for try_count in itertools.count(0):
             states = {node.config.name: node.post_boot(desired_ip_range) for node in nodes}
             node_names = ', '.join(states.keys())
             logger.info(f"Waiting for nodes ({node_names}) to have run post_boot (try #{try_count})..")

--- a/coreosBuilder.py
+++ b/coreosBuilder.py
@@ -135,10 +135,8 @@ class CoreosBuilder:
         cur_dir = os.getcwd()
         os.chdir(fcos_dir)
 
-        # -e COSA_NO_KVM=1 \
         cmd = f"""
-        podman run --rm -ti --security-opt label=disable --privileged         \
-               --uidmap=1000:0:1 --uidmap=0:1:1000 --uidmap 1001:1001:64536   \
+        podman run --rm -ti --userns=host -u root --privileged                \
                -v {fcos_dir}:/srv/ --device /dev/kvm --device /dev/fuse       \
                --tmpfs /tmp -v /var/tmp:/var/tmp --name cosa                  \
                -v {config_dir}:/git:ro                                        \
@@ -194,8 +192,7 @@ class CoreosBuilder:
             logger.info(f"Writing ignition to {ign}")
             f.write(ign)
 
-        if os.path.exists(dst):
-            os.remove(dst)
+        os.makedirs(os.path.dirname(dst), exist_ok=True)
 
         cmd = f"coreos-installer iso ignition embed -i {fn_ign} -o {dst} {embed_src}"
         lh = host.LocalHost()

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 if [ "$(which python)" = "$(pwd)/ocp-venv/bin/python" ]; then
     PYTHON_CMD="python"
 else


### PR DESCRIPTION
With this we can now deploy fully virtualized clusters on a single physical node (workers and masters running in VMs on the same host).