### PR TITLE
[th/ipa-validate] ignore invalid JSON input to `ipa_to_entries()`

### DIFF
--- a/clusterHost.py
+++ b/clusterHost.py
@@ -156,7 +156,7 @@ class ClusterHost:
         assert self.api_port is not None
 
         logger.info(f'Validating API network port {self.api_port}')
-        if not self.hostconn.port_exists(self.api_port):
+        if not common.ip_links(self.hostconn, ifname=self.api_port):
             logger.error(f"Can't find API network port {self.api_port}")
             return
         if not any(a.has_carrier() for a in common.ip_addrs(self.hostconn, ifname=self.api_port)):

--- a/clusterHost.py
+++ b/clusterHost.py
@@ -159,7 +159,7 @@ class ClusterHost:
         if not self.hostconn.port_exists(self.api_port):
             logger.error(f"Can't find API network port {self.api_port}")
             return
-        if not self.hostconn.port_has_carrier(self.api_port):
+        if not any(a.has_carrier() for a in common.ip_addrs(self.hostconn, ifname=self.api_port)):
             logger.error(f"API network port {self.api_port} doesn't have a carrier")
             return
 

--- a/clustersConfig.py
+++ b/clustersConfig.py
@@ -307,7 +307,7 @@ class ClustersConfig:
             logger.error(f"Not all master/worker IPs are in the reserved cluster IP range ({self.ip_range}).  Other hosts in the network might be offered those IPs via DHCP.")
 
     def validate_external_port(self) -> bool:
-        return host.LocalHost().port_exists(self.external_port)
+        return bool(common.ip_links(host.LocalHost(), ifname=self.external_port))
 
     def _apply_jinja(self, contents: str, cluster_name: str) -> str:
         def worker_number(a: int) -> str:

--- a/common.py
+++ b/common.py
@@ -160,7 +160,7 @@ def _parse_json_list(jstr: str, *, strict_parsing: bool = False) -> list[typing.
     return typing.cast(list[typing.Any], lst)
 
 
-def ip_addrs_parse(jstr: str, *, strict_parsing: bool = False) -> list[IPRouteAddressEntry]:
+def ip_addrs_parse(jstr: str, *, strict_parsing: bool = False, ifname: Optional[str] = None) -> list[IPRouteAddressEntry]:
     ret: list[IPRouteAddressEntry] = []
     for e in _parse_json_list(jstr, strict_parsing=strict_parsing):
         try:
@@ -177,18 +177,20 @@ def ip_addrs_parse(jstr: str, *, strict_parsing: bool = False) -> list[IPRouteAd
                 raise
             continue
 
+        if ifname is not None and entry.ifname != ifname:
+            continue
         ret.append(entry)
     return ret
 
 
-def ip_addrs(rsh: host.Host, *, strict_parsing: bool = False) -> list[IPRouteAddressEntry]:
+def ip_addrs(rsh: host.Host, *, strict_parsing: bool = False, ifname: Optional[str] = None) -> list[IPRouteAddressEntry]:
     ret = rsh.run("ip -json addr")
     if ret.returncode != 0:
         if strict_parsing:
             raise RuntimeError(f"calling ip-route on {rsh.hostname()} failed ({ret})")
         return []
 
-    return ip_addrs_parse(ret.out, strict_parsing=strict_parsing)
+    return ip_addrs_parse(ret.out, strict_parsing=strict_parsing, ifname=ifname)
 
 
 @strict_dataclass

--- a/common.py
+++ b/common.py
@@ -140,6 +140,9 @@ class IPRouteAddressEntry:
     address: str  # Ethernet address.
     addr_info: list[IPRouteAddressInfoEntry]
 
+    def has_carrier(self) -> bool:
+        return "NO-CARRIER" not in self.flags
+
 
 def _parse_json_list(jstr: str, *, strict_parsing: bool = False) -> list[typing.Any]:
     try:

--- a/common.py
+++ b/common.py
@@ -119,12 +119,18 @@ class RangeList:
         return [initial[x] for x in sorted(applied) if x < len(initial)]
 
 
+@strict_dataclass
 @dataclass
 class IPRouteAddressInfoEntry:
     family: str
     local: str
 
+    def _post_check(self) -> None:
+        if not isinstance(self.family, str) or self.family not in ("inet", "inet6"):
+            raise ValueError("Invalid address family")
 
+
+@strict_dataclass
 @dataclass
 class IPRouteAddressEntry:
     ifindex: int
@@ -183,6 +189,7 @@ def ipr(host: host.Host) -> str:
     return host.run("ip -json r").out
 
 
+@strict_dataclass
 @dataclass
 class IPRouteRouteEntry:
     dst: str

--- a/extraConfigDpuTenant.py
+++ b/extraConfigDpuTenant.py
@@ -13,6 +13,7 @@ import os
 import re
 from logger import logger
 from clustersConfig import ExtraConfigArgs
+import common
 
 
 def ExtraConfigDpuTenantMC(cc: ClustersConfig, _: ExtraConfigArgs, futures: dict[str, Future[Optional[host.Result]]]) -> None:
@@ -115,8 +116,8 @@ def _ExtraConfigDpuTenant_common(cc: ClustersConfig, cfg: ExtraConfigArgs, futur
     logger.info(f"BF is at {bf}")
 
     bf_port = None
-    for port in rh.all_ports():
-        ret = rh.run(f'ethtool -i {port["ifname"]}')
+    for port in common.ip_links(rh):
+        ret = rh.run(f'ethtool -i {port.ifname}')
         if ret.returncode != 0:
             continue
 
@@ -125,7 +126,7 @@ def _ExtraConfigDpuTenant_common(cc: ClustersConfig, cfg: ExtraConfigArgs, futur
             key, value = part.split(":", 1)
             d[key] = value
         if d["bus-info"].endswith(bf):
-            bf_port = port["ifname"]
+            bf_port = port.ifname
     logger.info(bf_port)
     if bf_port is None:
         logger.info("Couldn't find bf port")

--- a/host.py
+++ b/host.py
@@ -4,7 +4,6 @@ import io
 import os
 import re
 import time
-import json
 import shlex
 import shutil
 import sys
@@ -12,7 +11,6 @@ import logging
 import tempfile
 from typing import Optional
 from typing import Union
-from typing import Any
 from functools import lru_cache
 from ailib import Redfish
 import paramiko
@@ -415,9 +413,6 @@ class Host:
 
         ret = self.run(f"virsh dominfo {name}", logging.DEBUG)
         return not ret.returncode and state_running(ret.out)
-
-    def all_ports(self) -> Any:
-        return json.loads(self.run("ip -json link", logging.DEBUG).out)
 
     def port_exists(self, port_name: str) -> bool:
         return self.run(f"ip link show {port_name}").returncode == 0

--- a/host.py
+++ b/host.py
@@ -425,12 +425,6 @@ class Host:
     def port_exists(self, port_name: str) -> bool:
         return self.run(f"ip link show {port_name}").returncode == 0
 
-    def port_has_carrier(self, port_name: str) -> bool:
-        ports = {x["ifname"]: x for x in self.ipa()}
-        if port_name not in ports:
-            return False
-        return "NO-CARRIER" not in ports[port_name]["flags"]
-
     def write(self, fn: str, contents: str) -> None:
         if self.is_localhost():
             with open(fn, "w") as f:

--- a/host.py
+++ b/host.py
@@ -414,9 +414,6 @@ class Host:
         ret = self.run(f"virsh dominfo {name}", logging.DEBUG)
         return not ret.returncode and state_running(ret.out)
 
-    def port_exists(self, port_name: str) -> bool:
-        return self.run(f"ip link show {port_name}").returncode == 0
-
     def write(self, fn: str, contents: str) -> None:
         if self.is_localhost():
             with open(fn, "w") as f:

--- a/host.py
+++ b/host.py
@@ -419,9 +419,6 @@ class Host:
     def ipa(self) -> Any:
         return json.loads(self.run("ip -json a", logging.DEBUG).out)
 
-    def ipr(self) -> Any:
-        return json.loads(self.run("ip -json r", logging.DEBUG).out)
-
     def all_ports(self) -> Any:
         return json.loads(self.run("ip -json link", logging.DEBUG).out)
 

--- a/host.py
+++ b/host.py
@@ -416,9 +416,6 @@ class Host:
         ret = self.run(f"virsh dominfo {name}", logging.DEBUG)
         return not ret.returncode and state_running(ret.out)
 
-    def ipa(self) -> Any:
-        return json.loads(self.run("ip -json a", logging.DEBUG).out)
-
     def all_ports(self) -> Any:
         return json.loads(self.run("ip -json link", logging.DEBUG).out)
 

--- a/test_common.py
+++ b/test_common.py
@@ -1,6 +1,9 @@
+import dataclasses
+import os
 import pathlib
 import pytest
-import os
+import typing
+
 
 import common
 
@@ -80,3 +83,106 @@ def test_ip_address() -> None:
     assert common.ipaddr_norm(" 1::01  ") == "1::1"
     assert common.ipaddr_norm(b" 1::01  ") == "1::1"
     assert common.ipaddr_norm(b" 1::01  ") == "1::1"
+
+
+def test_strict_dataclass() -> None:
+    @common.strict_dataclass
+    @dataclasses.dataclass
+    class C2:
+        a: str
+        b: int
+        c: typing.Optional[str] = None
+
+    C2("a", 5)
+    C2("a", 5, None)
+    C2("a", 5, "")
+    with pytest.raises(TypeError):
+        C2("a", "5")  # type: ignore
+    with pytest.raises(TypeError):
+        C2(3, 5)  # type: ignore
+    with pytest.raises(TypeError):
+        C2("a", 5, [])  # type: ignore
+
+    @common.strict_dataclass
+    @dataclasses.dataclass
+    class C3:
+        a: typing.List[str]
+
+    C3([])
+    C3([""])
+    with pytest.raises(TypeError):
+        C3(1)  # type: ignore
+    with pytest.raises(TypeError):
+        C3([1])  # type: ignore
+    with pytest.raises(TypeError):
+        C3(None)  # type: ignore
+
+    @common.strict_dataclass
+    @dataclasses.dataclass
+    class C4:
+        a: typing.Optional[typing.List[str]]
+
+    C4(None)
+
+    @common.strict_dataclass
+    @dataclasses.dataclass
+    class C5:
+        a: typing.Optional[typing.List[typing.Dict[str, str]]] = None
+
+    C5(None)
+    C5([])
+    with pytest.raises(TypeError):
+        C5([1])  # type: ignore
+    C5([{}])
+    C5([{"a": "b"}])
+    C5([{"a": "b"}, {}])
+    C5([{"a": "b"}, {"c": "", "d": "x"}])
+    with pytest.raises(TypeError):
+        C5([{"a": None}])  # type: ignore
+
+    @common.strict_dataclass
+    @dataclasses.dataclass
+    class C6:
+        a: typing.Optional[typing.Tuple[str, str]] = None
+
+    C6()
+    C6(None)
+    C6(("a", "b"))
+    with pytest.raises(TypeError):
+        C6(1)  # type: ignore
+    with pytest.raises(TypeError):
+        C6(("a",))  # type: ignore
+    with pytest.raises(TypeError):
+        C6(("a", "b", "c"))  # type: ignore
+    with pytest.raises(TypeError):
+        C6(("a", 1))  # type: ignore
+
+    @common.strict_dataclass
+    @dataclasses.dataclass
+    class C7:
+        addr_info: typing.List[common.IPRouteAddressInfoEntry]
+
+        def _post_check(self) -> None:
+            pass
+
+    with pytest.raises(TypeError):
+        C7(None)  # type: ignore
+    C7([])
+    C7([common.IPRouteAddressInfoEntry('inet', '169.254.2.115')])
+    with pytest.raises(TypeError):
+        C7([common.IPRouteAddressInfoEntry('inet', '169.254.2.115'), None])  # type: ignore
+
+    @common.strict_dataclass
+    @dataclasses.dataclass
+    class C8:
+        a: str
+
+        def _post_check(self) -> None:
+            if self.a == "invalid":
+                raise ValueError("_post_check() failed")
+
+    with pytest.raises(TypeError):
+        C8(None)  # type: ignore
+    C8("hi")
+    with pytest.raises(ValueError):
+        C8("invalid")

--- a/test_common.py
+++ b/test_common.py
@@ -6,6 +6,7 @@ import typing
 
 
 import common
+import host
 
 
 def _read_file(filename: str) -> str:
@@ -186,3 +187,9 @@ def test_strict_dataclass() -> None:
     C8("hi")
     with pytest.raises(ValueError):
         C8("invalid")
+
+
+def test_ip_routes() -> None:
+    # We expect to have at least one route configured on the system and that
+    # `ip -json route` works. The unit test requires that.
+    assert common.ip_routes(host.LocalHost())

--- a/test_common.py
+++ b/test_common.py
@@ -189,6 +189,12 @@ def test_strict_dataclass() -> None:
         C8("invalid")
 
 
+def test_ip_addrs() -> None:
+    # We expect to have at least one address configured on the system and that
+    # `ip -json addr` works. The unit test requires that.
+    assert common.ip_addrs(host.LocalHost())
+
+
 def test_ip_routes() -> None:
     # We expect to have at least one route configured on the system and that
     # `ip -json route` works. The unit test requires that.

--- a/test_common.py
+++ b/test_common.py
@@ -195,6 +195,14 @@ def test_ip_addrs() -> None:
     assert common.ip_addrs(host.LocalHost())
 
 
+def test_ip_links() -> None:
+    links = common.ip_links(host.LocalHost())
+    assert links
+    assert [link.ifindex for link in links if link.ifname == "lo"] == [1]
+
+    assert [link.ifindex for link in common.ip_links(host.LocalHost(), ifname="lo")] == [1]
+
+
 def test_ip_routes() -> None:
     # We expect to have at least one route configured on the system and that
     # `ip -json route` works. The unit test requires that.


### PR DESCRIPTION
- unify fetching links/addresses/routes via new/renamed API `common.ip_{links,addrs,routes}()`. Duplicated implementations are replaced.

- we fetch links/addresses/routes with a remote `ip -j link|addr|route show` call. The only sensible thing to do with that result is parsing it. That parsing should all use the same code. That code is now `common.ip_{links,addrs,routes}_parse()`. Note that most callers however are not even interested in that (because they always want the parsed output). Instead, `common.ip_{links,addrs,routes}()` gives already the parsed output and does not bother the caller with calling `ip -j link|addr|route show` separately.

- a remote call can easily fail. For example, while the worker machine is rebooting. Previously, that lead to an exception (which was mostly unhandled and crashed the tool). There is not much useful to handle about that error, because callers usually are more interested in the information they can fetch. Fetching no information would be threated the same as an error of fetching the information. Hence, the `common.ip_{links,addrs,routes}()` calls now "handle" any error by returning no result. If a caller really want to distinguish between missing information and an error to fetch the information, they can set `strict_parsing=True`.

- add a decorator `@strict_dataclass` for validating the values of a data class. While the branch "handles" all error by ignoring them (`strict_parsing=True`), we still want to be able to tell when something unexpected was returned. Previously, the data classes were just ininitialized with the values from the JSON, without further type checking.