### PR TITLE
Teardown vms

### DIFF
--- a/arguments.py
+++ b/arguments.py
@@ -8,7 +8,11 @@ import difflib
 from logger import logger, configure_logger
 from typing import Optional
 
-VALID_STEPS = ["pre", "masters", "workers", "post"]
+PRE_STEP = "pre"
+MASTERS_STEP = "masters"
+WORKERS_STEP = "workers"
+POST_STEP = "post"
+VALID_STEPS = [PRE_STEP, MASTERS_STEP, WORKERS_STEP, POST_STEP]
 
 
 def fuzzy_match(step: str) -> Optional[str]:

--- a/cda.py
+++ b/cda.py
@@ -38,7 +38,8 @@ def main_deploy(args: argparse.Namespace) -> None:
     cd = ClusterDeployer(cc, ai, args.steps, args.secrets_path)
 
     if args.teardown or args.teardown_full:
-        cd.teardown()
+        cd.teardown_workers()
+        cd.teardown_masters()
     else:
         cd.deploy()
 

--- a/clusterHost.py
+++ b/clusterHost.py
@@ -107,6 +107,22 @@ class ClusterHost:
 
         self.bridge.configure(self.api_port)
 
+    def setup_dhcp_entries(self, vms: list[NodeConfig]) -> None:
+        if not self.hosts_vms:
+            return
+
+        self.bridge.setup_dhcp_entries(vms)
+        # bridge.remove_dhcp_entries might remove the master of the bridge (through virsh net-destroy/net-start). Add it back.
+        self.ensure_linked_to_network(self.bridge)
+
+    def remove_dhcp_entries(self, vms: list[NodeConfig]) -> None:
+        if not self.hosts_vms:
+            return
+
+        self.bridge.remove_dhcp_entries(vms)
+        # bridge.remove_dhcp_entries might remove the master of the bridge (through virsh net-destroy/net-start). Add it back.
+        self.ensure_linked_to_network(self.bridge)
+
     def ensure_linked_to_network(self, dhcp_bridge: VirBridge) -> None:
         if not self.needs_api_network:
             return
@@ -153,19 +169,6 @@ class ClusterHost:
 
         logger.info(f"Removing DHCP reply drop rules on {self.api_port}")
         self.hostconn.run("ebtables -t filter -F FORWARD")
-
-    def _configure_dhcp_entries(self, dhcp_bridge: VirBridge, nodes: list[ClusterNode]) -> None:
-        if not self.hosts_vms:
-            return
-
-        for node in nodes:
-            dhcp_bridge.setup_dhcp_entry(node.config)
-
-    def configure_master_dhcp_entries(self, dhcp_bridge: VirBridge) -> None:
-        return self._configure_dhcp_entries(dhcp_bridge, self.k8s_master_nodes)
-
-    def configure_worker_dhcp_entries(self, dhcp_bridge: VirBridge) -> None:
-        return self._configure_dhcp_entries(dhcp_bridge, self.k8s_worker_nodes)
 
     def preinstall(self, external_port: str, executor: ThreadPoolExecutor) -> Future[None]:
         def _preinstall() -> None:
@@ -231,6 +234,6 @@ class ClusterHost:
     def wait_for_workers_boot(self, desired_ip_range: tuple[str, str]) -> None:
         return self._wait_for_boot(self.k8s_worker_nodes, desired_ip_range)
 
-    def teardown(self) -> None:
-        for node in self._k8s_nodes():
+    def teardown_nodes(self, nodes: list[ClusterNode]) -> None:
+        for node in nodes:
             node.teardown()

--- a/clusterHost.py
+++ b/clusterHost.py
@@ -117,6 +117,8 @@ class ClusterHost:
             logger.error_and_exit(f"Host {self.config.name} misses API network interface {self.api_port}")
 
         logger.info(f"Block all DHCP replies on {self.api_port} except the ones coming from the DHCP bridge")
+        # We might run ensure_linked_to_network on a host on which ebtables rules are already installed e.g. adding vms on a host already hosting vms.
+        self.hostconn.run("ebtables -t filter -F FORWARD")
         self.hostconn.run(f"ebtables -t filter -A FORWARD -p IPv4 --in-interface {self.api_port} --src {dhcp_bridge.eth_address()} --ip-proto udp --ip-sport 67 --ip-dport 68 -j ACCEPT")
         self.hostconn.run(f"ebtables -t filter -A FORWARD -p IPv4 --in-interface {self.api_port} --ip-proto udp --ip-sport 67 --ip-dport 68 -j DROP")
 

--- a/k8sClient.py
+++ b/k8sClient.py
@@ -40,6 +40,10 @@ class K8sClient:
                 cb()
             self.approve_csr()
 
+    def delete_node(self, node: str) -> None:
+        logger.info(f"Deleting node {node}")
+        self.oc(f"delete node {node}")
+
     def approve_csr(self) -> None:
         certs_api = kubernetes.client.CertificatesV1Api(self._api_client)
         for e in certs_api.list_certificate_signing_request().items:


### PR DESCRIPTION
Add ability to tear down only workers.

4 patches:
- create remove_dhcp_entries for masters and workers. This removes dhcp entries per host.
- Fix dhcp leases cleaning. Some race conditions were sometimes causing cleaning issues. Note that --wait in virsh does not work.
- Add support for teardown workers only.
- Support non consecutive static ip for nodes. So that we can configure ip as e.g. a.b.c.5, ab.c..7 ... and proper range will be calculated.