### PR TITLE
[Draft] [th/host-no-bmc] separate host.Host and host.BMC

### DIFF
--- a/clusterNode.py
+++ b/clusterNode.py
@@ -199,10 +199,10 @@ class X86ClusterNode(ClusterNode):
         nfs = NFS(lh, self.external_port)
 
         bmc = BMC.from_bmc(self.config.bmc, self.config.bmc_user, self.config.bmc_password)
-        h = host.HostWithBF2(self.config.node, bmc)
+        h = host.HostWithBF2(self.config.node)
 
         iso = nfs.host_file(os.path.join(os.getcwd(), iso))
-        h.boot_iso_redfish(iso)
+        bmc.boot_iso_redfish(iso)
         h.ssh_connect("core")
         logger.info("connected")
         return h.run("hostname")
@@ -245,7 +245,7 @@ class BFClusterNode(ClusterNode):
 
         logger.info(f"Preparing BF on host {self.config.node}")
         bmc = BMC.from_bmc(self.config.bmc, self.config.bmc_user, self.config.bmc_password)
-        h = host.HostWithBF2(self.config.node, bmc)
+        h = host.HostWithBF2(self.config.node)
         skip_boot = False
         if h.ping():
             try:
@@ -258,7 +258,7 @@ class BFClusterNode(ClusterNode):
             logger.info(f"Skipping booting {self.config.node}, already booted with FCOS")
         else:
             nfs_file = nfs.host_file("/root/iso/fedora-coreos.iso")
-            h.boot_iso_redfish(nfs_file)
+            bmc.boot_iso_redfish(nfs_file)
             time.sleep(10)
             h.ssh_connect("core")
 

--- a/clusterSnapshotter.py
+++ b/clusterSnapshotter.py
@@ -41,7 +41,10 @@ class ClusterSnapshotter:
             rh = host.RemoteHost(node)
             nfs = NFS(host.LocalHost(), self._cc.external_port)
             file = nfs.host_file("/root/iso/fedora-coreos.iso")
-            rh.boot_iso_redfish(file)
+
+            bmc = host.BMC.from_bmc(rh.hostname())
+            bmc.boot_iso_redfish(file)
+
             logger.info(f"Backing up node {node}")
             rh.ssh_connect("core")
             rh.run("sudo mount /dev/sdb1 /mnt/")
@@ -95,7 +98,10 @@ class ClusterSnapshotter:
             rh = host.RemoteHost(node)
             nfs = NFS(host.LocalHost(), self._cc.external_port)
             file = nfs.host_file("/root/iso/fedora-coreos.iso")
-            rh.boot_iso_redfish(file)
+
+            bmc = host.BMC.from_bmc(rh.hostname())
+            bmc.boot_iso_redfish(file)
+
             logger.info(f"Restoring node {node}")
             rh.ssh_connect("core")
             rh.run("sudo mount /dev/sdb1 /mnt/")

--- a/host.py
+++ b/host.py
@@ -197,16 +197,15 @@ class BMC:
 
 
 class Host:
-    def __new__(cls, hostname: str, bmc: Optional[BMC] = None) -> 'Host':
-        key = (hostname, bmc.url if bmc else None)
+    def __new__(cls, hostname: str) -> 'Host':
+        key = hostname
         if key not in host_instances:
             host_instances[key] = super().__new__(cls)
             logger.debug(f"new instance for {hostname}")
         return host_instances[key]
 
-    def __init__(self, hostname: str, bmc: Optional[BMC] = None):
+    def __init__(self, hostname: str):
         self._hostname = hostname
-        self._bmc = bmc
         self._logins: list[Login] = []
         self.sudo_needed = False
 
@@ -363,26 +362,6 @@ class Host:
     def close(self) -> None:
         assert self._host is not None
         self._host.close()
-
-    def boot_iso_redfish(self, iso_path: str) -> None:
-        if self._bmc is None:
-            raise Exception(f"Can't boot iso without bmc on {self.hostname()}")
-        self._bmc.boot_iso_redfish(iso_path)
-
-    def stop(self) -> None:
-        if self._bmc is None:
-            raise Exception(f"Can't stop host without bmc on {self.hostname()}")
-        self._bmc.stop()
-
-    def start(self) -> None:
-        if self._bmc is None:
-            raise Exception(f"Can't start host without bmc on {self.hostname()}")
-        self._bmc.start()
-
-    def cold_boot(self) -> None:
-        if self._bmc is None:
-            raise Exception(f"Can't cold boot host without bmc on {self.hostname()}")
-        self._bmc.cold_boot()
 
     def wait_ping(self) -> None:
         while not self.ping():
@@ -566,7 +545,7 @@ class HostWithBF2(Host):
         return self.run_in_container("/bfb")
 
 
-host_instances: dict[tuple[str, Optional[str]], Host] = {}
+host_instances: dict[str, Host] = {}
 
 
 def sync_time(src: Host, dst: Host) -> Result:

--- a/host.py
+++ b/host.py
@@ -213,6 +213,23 @@ class Host:
     def is_localhost(self) -> bool:
         return self._hostname in ("localhost", socket.gethostname())
 
+    @staticmethod
+    def ssh_run(sshclient: paramiko.SSHClient, cmd: str, log_prefix: str, log_level: int = logging.DEBUG) -> Result:
+        _, stdout, stderr = sshclient.exec_command(cmd)
+
+        out = []
+        for line in iter(stdout.readline, ""):
+            logger.log(log_level, f"{log_prefix}: stdout: {line.strip()}")
+            out.append(line)
+
+        err = []
+        for line in iter(stderr.readline, ""):
+            logger.log(log_level, f"{log_prefix}: stderr: {line.strip()}")
+            err.append(line)
+
+        exit_code = stdout.channel.recv_exit_status()
+        return Result("".join(out), "".join(err), exit_code)
+
     def ssh_connect(self, username: str, password: Optional[str] = None, rsa_path: str = default_id_rsa_path(), ed25519_path: str = default_ed25519_path()) -> None:
         assert not self.is_localhost()
         logger.info(f"waiting for '{self._hostname}' to respond to ping")
@@ -323,28 +340,11 @@ class Host:
         return Result(out, err, ret)
 
     def _run_remote(self, cmd: str, log_level: int) -> Result:
-        def read_output(cmd: str, log_level: int) -> Result:
-            assert self._host is not None
-            _, stdout, stderr = self._host.exec_command(cmd)
-
-            out = []
-            for line in iter(stdout.readline, ""):
-                logger.log(log_level, f"{self._hostname}: {line.strip()}")
-                out.append(line)
-
-            err = []
-            for line in iter(stderr.readline, ""):
-                err.append(line)
-
-            exit_code = stdout.channel.recv_exit_status()
-
-            return Result("".join(out), "".join(err), exit_code)
-
         # Make sure multiline command is not seen as multiple commands
         cmd = cmd.replace("\n", "\\\n")
         while True:
             try:
-                return read_output(cmd, log_level)
+                return self.ssh_run(self._host, cmd, log_prefix=self._hostname, log_level=log_level)
             except Exception as e:
                 logger.log(log_level, e)
                 logger.log(log_level, f"Connection lost while running command {cmd}, reconnecting...")
@@ -491,19 +491,7 @@ class HostWithBF2(Host):
         self._bf_host.connect(bf_addr, username='core', pkey=pkey, sock=chan)
 
     def run_on_bf(self, cmd: str, log_level: int = logging.DEBUG) -> Result:
-        _, stdout, stderr = self._bf_host.exec_command(cmd)
-
-        out = []
-        for line in iter(stdout.readline, ""):
-            logger.log(log_level, f"{self._hostname} -> BF: {line.strip()}")
-            out.append(line)
-
-        err: list[str] = []
-        for line in iter(stderr.readline, ""):
-            err.append(line)
-
-        exit_code = stdout.channel.recv_exit_status()
-        return Result("".join(out), "".join(err), exit_code)
+        return self.ssh_run(self._bf_host, cmd, log_prefix=f"{self._hostname}:BF", log_level=log_level)
 
     def run_in_container(self, cmd: str, interactive: bool = False) -> Result:
         name = "bf"

--- a/microshift.py
+++ b/microshift.py
@@ -219,7 +219,7 @@ rhsm = true'''.strip()
 def deploy(cluster_name: str, node: NodeConfig, external_port: str, version: str) -> None:
     lh = host.LocalHost()
     bmc = BMC.from_bmc(node.bmc, node.bmc_user, node.bmc_password)
-    h = Host(node.node, bmc)
+    h = Host(node.node)
     name_of_final_iso = os.path.join(os.getcwd(), 'final.iso')
     login_uname = "redhat"
 
@@ -234,6 +234,6 @@ def deploy(cluster_name: str, node: NodeConfig, external_port: str, version: str
 
     nfs = NFS(lh, external_port)
     iso = nfs.host_file(name_of_final_iso)
-    h.boot_iso_redfish(iso)
+    bmc.boot_iso_redfish(iso)
     h.ssh_connect(login_uname)
     logger.info("Microshift finished booting")


### PR DESCRIPTION
don't attach the `host.BMC` instance to `host.Host` as `host._bmc`.

these are entirely separate functionality, and there is no need that `host.Host` would be concerned with BMC.