### PR TITLE
[th/typing-standard-collections] use standard collections (like `list`) instead of `typing.List`

### DIFF
--- a/arguments.py
+++ b/arguments.py
@@ -7,7 +7,6 @@ import argcomplete
 import difflib
 from logger import logger, configure_logger
 from typing import Optional
-from typing import List
 
 VALID_STEPS = ["pre", "masters", "workers", "post"]
 
@@ -21,11 +20,11 @@ def join_valid_steps() -> str:
     return ','.join(VALID_STEPS)
 
 
-def yaml_completer(prefix: str, parsed_args: str, **kwargs: str) -> List[str]:
+def yaml_completer(prefix: str, parsed_args: str, **kwargs: str) -> list[str]:
     return [f for f in os.listdir('.') if (f.endswith(('.yaml', '.yml')) and f.startswith(prefix))]
 
 
-def step_completer(prefix: str, parsed_args: str, **kwargs: str) -> List[str]:
+def step_completer(prefix: str, parsed_args: str, **kwargs: str) -> list[str]:
     if not prefix:
         return VALID_STEPS
 
@@ -44,7 +43,7 @@ def step_completer(prefix: str, parsed_args: str, **kwargs: str) -> List[str]:
     return suggestions
 
 
-def remove_empty_strings(comma_string: str) -> List[str]:
+def remove_empty_strings(comma_string: str) -> list[str]:
     return list(filter(None, comma_string.split(",")))
 
 

--- a/assistedInstaller.py
+++ b/assistedInstaller.py
@@ -8,7 +8,6 @@ import requests
 from ailib import AssistedClient
 import common
 from logger import logger
-from typing import Tuple
 import sys
 
 
@@ -122,7 +121,7 @@ class AssistedClientAutomation(AssistedClient):  # type: ignore
                 return AssistedClientHostInfo(h["status"], h["inventory"])
         return None
 
-    def get_ai_ip(self, name: str, ip_range: Tuple[str, str]) -> Optional[str]:
+    def get_ai_ip(self, name: str, ip_range: tuple[str, str]) -> Optional[str]:
         ai_host = self.get_ai_host(name)
         if ai_host:
             inventory = json.loads(ai_host.inventory)

--- a/assistedInstaller.py
+++ b/assistedInstaller.py
@@ -8,7 +8,7 @@ import requests
 from ailib import AssistedClient
 import common
 from logger import logger
-from typing import Dict, Tuple
+from typing import Tuple
 import sys
 
 
@@ -40,7 +40,7 @@ class AssistedClientAutomation(AssistedClient):  # type: ignore
                 logger.info("failed to delete cluster, will retry..")
             time.sleep(5)
 
-    def ensure_infraenv_created(self, name: str, cfg: Dict[str, str]) -> None:
+    def ensure_infraenv_created(self, name: str, cfg: dict[str, str]) -> None:
         if name not in (x["name"] for x in self.list_infra_envs()):
             logger.info(f"Creating infraenv {name}")
             self.create_infra_env(name, cfg)

--- a/assistedInstallerService.py
+++ b/assistedInstallerService.py
@@ -6,7 +6,6 @@ import sys
 import re
 import filecmp
 from typing import Optional
-from typing import Dict
 from typing import Union
 from typing import Any
 from typing import Sequence
@@ -89,7 +88,7 @@ class AssistedInstallerService:
     def _last_run_pod(self) -> str:
         return f'{self.workdir}/pod-persistent-last.yml'
 
-    def _customized_configmap(self) -> Dict[str, str]:
+    def _customized_configmap(self) -> dict[str, str]:
         y = yaml.safe_load(self.podConfig)
         if not isinstance(y, dict):
             logger.error(f"Failed to load yaml: {self.podConfig}")
@@ -119,7 +118,7 @@ class AssistedInstallerService:
             y["data"]["no_proxy"] = self._noproxy
         return y
 
-    def _customized_pod_persistent(self) -> Dict[str, str]:
+    def _customized_pod_persistent(self) -> dict[str, str]:
         y = yaml.safe_load(self.podFile)
         if not isinstance(y, dict):
             logger.error(f"Failed to load yaml: {self.podFile}")
@@ -133,7 +132,7 @@ class AssistedInstallerService:
 
         return y
 
-    def prep_version(self, version: str) -> Dict[str, Union[str, Sequence[str]]]:
+    def prep_version(self, version: str) -> dict[str, Union[str, Sequence[str]]]:
         if re.search(r'4\.12\.[0-9]+', version):
             # Note how 4.12.0 has the -multi suffix because AI requires that
             # for 4.12. CDA hides this and simply expect 4.12.0 from the user

--- a/clusterDeployer.py
+++ b/clusterDeployer.py
@@ -10,7 +10,6 @@ from typing import Optional
 from typing import Generator
 from typing import Union
 from typing import Callable
-from typing import Set
 import re
 import logging
 from assistedInstaller import AssistedClientAutomation
@@ -66,10 +65,10 @@ class ClusterDeployer:
             self.workers_arch = "x86_64"
         self._validate()
 
-    def _all_hosts_with_masters(self) -> Set[ClusterHost]:
+    def _all_hosts_with_masters(self) -> set[ClusterHost]:
         return {ch for ch in self._all_hosts if len(ch.k8s_master_nodes) > 0}
 
-    def _all_hosts_with_workers(self) -> Set[ClusterHost]:
+    def _all_hosts_with_workers(self) -> set[ClusterHost]:
         return {ch for ch in self._all_hosts if len(ch.k8s_worker_nodes) > 0}
 
     """

--- a/clusterDeployer.py
+++ b/clusterDeployer.py
@@ -10,7 +10,6 @@ from typing import Optional
 from typing import Generator
 from typing import Dict
 from typing import Union
-from typing import List
 from typing import Callable
 from typing import Set
 import re
@@ -37,7 +36,7 @@ def match_to_proper_version_format(version_cluster_config: str) -> str:
 
 
 class ClusterDeployer:
-    def __init__(self, cc: ClustersConfig, ai: AssistedClientAutomation, steps: List[str], secrets_path: str):
+    def __init__(self, cc: ClustersConfig, ai: AssistedClientAutomation, steps: list[str], secrets_path: str):
         self._client: Optional[K8sClient] = None
         self.steps = steps
         self._cc = cc
@@ -264,7 +263,7 @@ class ClusterDeployer:
 
     def create_cluster(self) -> None:
         cluster_name = self._cc.name
-        cfg: Dict[str, Union[str, bool, List[str], List[Dict[str, str]]]] = {}
+        cfg: Dict[str, Union[str, bool, list[str], list[Dict[str, str]]]] = {}
         cfg["openshift_version"] = self._cc.version
         cfg["cpu_architecture"] = "multi"
         cfg["pull_secret"] = self._secrets_path
@@ -460,7 +459,7 @@ class ClusterDeployer:
         ip_range = self._cc.full_ip_range
         logger.info(f"Connectivity established to all workers; checking that they have an IP in range: {ip_range}")
 
-        def addresses(h: host.Host) -> List[str]:
+        def addresses(h: host.Host) -> list[str]:
             ret = []
             for e in h.ipa():
                 if "addr_info" not in e:
@@ -504,7 +503,7 @@ class ClusterDeployer:
                     if "inventory" not in h:
                         continue
                     nics = json.loads(h["inventory"]).get("interfaces")
-                    addresses: List[str] = sum((nic["ipv4_addresses"] for nic in nics), [])
+                    addresses: list[str] = sum((nic["ipv4_addresses"] for nic in nics), [])
                     stripped_addresses = [a.split("/")[0] for a in addresses]
 
                     if k8s_node.ip() in stripped_addresses:

--- a/clusterDeployer.py
+++ b/clusterDeployer.py
@@ -8,7 +8,6 @@ import shutil
 from concurrent.futures import ThreadPoolExecutor
 from typing import Optional
 from typing import Generator
-from typing import Dict
 from typing import Union
 from typing import Callable
 from typing import Set
@@ -241,9 +240,9 @@ class ClusterDeployer:
     def _wait_known_state(self, names_gen: Generator[str, None, None], cb: Callable[[], None] = lambda: None) -> None:
         names = list(names_gen)
         logger.info(f"Waiting for {names} to be in \'known\' state")
-        status: Dict[str, Optional[str]] = {n: "" for n in names}
+        status: dict[str, Optional[str]] = {n: "" for n in names}
         while not all(v == "known" for v in status.values()):
-            new_status: Dict[str, Optional[str]] = {n: self._get_status(n) for n in names}
+            new_status: dict[str, Optional[str]] = {n: self._get_status(n) for n in names}
             if new_status != status:
                 logger.info(f"latest status: {new_status}")
                 status = new_status
@@ -263,7 +262,7 @@ class ClusterDeployer:
 
     def create_cluster(self) -> None:
         cluster_name = self._cc.name
-        cfg: Dict[str, Union[str, bool, list[str], list[Dict[str, str]]]] = {}
+        cfg: dict[str, Union[str, bool, list[str], list[dict[str, str]]]] = {}
         cfg["openshift_version"] = self._cc.version
         cfg["cpu_architecture"] = "multi"
         cfg["pull_secret"] = self._secrets_path
@@ -552,7 +551,7 @@ class ClusterDeployer:
         logger.info(f'waiting for {len(self._cc.workers)} workers')
         lh = host.LocalHost()
         bf_workers = [x for x in self._cc.workers if x.kind == "bf"]
-        connections: Dict[str, host.Host] = {}
+        connections: dict[str, host.Host] = {}
         for try_count in itertools.count(0):
             workers = [w.name for w in self._cc.workers]
             n_not_ready_workers = sum(1 for w in workers if not self.client().is_ready(w))

--- a/clusterHost.py
+++ b/clusterHost.py
@@ -3,7 +3,7 @@ import os
 import time
 from concurrent.futures import Future, ThreadPoolExecutor
 from logger import logger
-from typing import List, Optional, Tuple
+from typing import Optional, Tuple
 
 import common
 import coreosBuilder
@@ -26,8 +26,8 @@ class ClusterHost:
     config: HostConfig
     needs_api_network: bool
     api_port: Optional[str] = None
-    k8s_master_nodes: List[ClusterNode]
-    k8s_worker_nodes: List[ClusterNode]
+    k8s_master_nodes: list[ClusterNode]
+    k8s_worker_nodes: list[ClusterNode]
     hosts_vms: bool
 
     def __init__(self, h: host.Host, c: HostConfig, cc: ClustersConfig, bc: BridgeConfig, serves_dhcp: bool):
@@ -35,8 +35,8 @@ class ClusterHost:
         self.hostconn = h
         self.config = c
 
-        def _create_k8s_nodes(configs: List[NodeConfig]) -> List[ClusterNode]:
-            nodes: List[ClusterNode] = []
+        def _create_k8s_nodes(configs: list[NodeConfig]) -> list[ClusterNode]:
+            nodes: list[ClusterNode] = []
             for node_config in configs:
                 if node_config.node != self.config.name:
                     continue
@@ -71,10 +71,10 @@ class ClusterHost:
                 logger.error_and_exit(f"Can't find a valid network API port, config is {self.config.network_api_port}")
             logger.info(f"Using {self.api_port} as network API port")
 
-    def _k8s_nodes(self) -> List[ClusterNode]:
+    def _k8s_nodes(self) -> list[ClusterNode]:
         return self.k8s_master_nodes + self.k8s_worker_nodes
 
-    def _ensure_images(self, local_iso_path: str, infra_env: str, nodes: List[ClusterNode]) -> None:
+    def _ensure_images(self, local_iso_path: str, infra_env: str, nodes: list[ClusterNode]) -> None:
         if not self.hosts_vms:
             return
 
@@ -139,7 +139,7 @@ class ClusterHost:
         logger.info(f"Removing DHCP reply drop rules on {self.api_port}")
         self.hostconn.run("ebtables -t filter -F FORWARD")
 
-    def _configure_dhcp_entries(self, dhcp_bridge: VirBridge, nodes: List[ClusterNode]) -> None:
+    def _configure_dhcp_entries(self, dhcp_bridge: VirBridge, nodes: list[ClusterNode]) -> None:
         if not self.hosts_vms:
             return
 
@@ -168,7 +168,7 @@ class ClusterHost:
 
         return executor.submit(_preinstall)
 
-    def _start_nodes(self, iso_path: str, infra_env: str, executor: ThreadPoolExecutor, nodes: List[ClusterNode]) -> List[Future[Optional[host.Result]]]:
+    def _start_nodes(self, iso_path: str, infra_env: str, executor: ThreadPoolExecutor, nodes: list[ClusterNode]) -> list[Future[Optional[host.Result]]]:
         self._ensure_images(iso_path, infra_env, nodes)
         futures = []
         for node in nodes:
@@ -177,13 +177,13 @@ class ClusterHost:
             futures.append(node.future)
         return futures
 
-    def start_masters(self, iso_path: str, infra_env: str, executor: ThreadPoolExecutor) -> List[Future[Optional[host.Result]]]:
+    def start_masters(self, iso_path: str, infra_env: str, executor: ThreadPoolExecutor) -> list[Future[Optional[host.Result]]]:
         return self._start_nodes(iso_path, infra_env, executor, self.k8s_master_nodes)
 
-    def start_workers(self, iso_path: str, infra_env: str, executor: ThreadPoolExecutor) -> List[Future[Optional[host.Result]]]:
+    def start_workers(self, iso_path: str, infra_env: str, executor: ThreadPoolExecutor) -> list[Future[Optional[host.Result]]]:
         return self._start_nodes(iso_path, infra_env, executor, self.k8s_worker_nodes)
 
-    def _wait_for_boot(self, nodes: List[ClusterNode], desired_ip_range: Tuple[str, str]) -> None:
+    def _wait_for_boot(self, nodes: list[ClusterNode], desired_ip_range: Tuple[str, str]) -> None:
         if not nodes:
             return
 

--- a/clusterHost.py
+++ b/clusterHost.py
@@ -3,7 +3,7 @@ import os
 import time
 from concurrent.futures import Future, ThreadPoolExecutor
 from logger import logger
-from typing import Optional, Tuple
+from typing import Optional
 
 import common
 import coreosBuilder
@@ -183,7 +183,7 @@ class ClusterHost:
     def start_workers(self, iso_path: str, infra_env: str, executor: ThreadPoolExecutor) -> list[Future[Optional[host.Result]]]:
         return self._start_nodes(iso_path, infra_env, executor, self.k8s_worker_nodes)
 
-    def _wait_for_boot(self, nodes: list[ClusterNode], desired_ip_range: Tuple[str, str]) -> None:
+    def _wait_for_boot(self, nodes: list[ClusterNode], desired_ip_range: tuple[str, str]) -> None:
         if not nodes:
             return
 
@@ -210,10 +210,10 @@ class ClusterHost:
         for node in nodes:
             node.health_check()
 
-    def wait_for_masters_boot(self, desired_ip_range: Tuple[str, str]) -> None:
+    def wait_for_masters_boot(self, desired_ip_range: tuple[str, str]) -> None:
         return self._wait_for_boot(self.k8s_master_nodes, desired_ip_range)
 
-    def wait_for_workers_boot(self, desired_ip_range: Tuple[str, str]) -> None:
+    def wait_for_workers_boot(self, desired_ip_range: tuple[str, str]) -> None:
         return self._wait_for_boot(self.k8s_worker_nodes, desired_ip_range)
 
     def teardown(self) -> None:

--- a/clusterInfo.py
+++ b/clusterInfo.py
@@ -1,4 +1,3 @@
-from typing import Dict
 import sys
 import os
 import gspread
@@ -34,7 +33,7 @@ def read_sheet() -> list[list[str]]:
     return [list(e.values()) for e in sheet.get_all_records()]
 
 
-def load_all_cluster_info() -> Dict[str, ClusterInfo]:
+def load_all_cluster_info() -> dict[str, ClusterInfo]:
     cluster = None
     ret = []
     logger.info("loading cluster information")

--- a/clusterInfo.py
+++ b/clusterInfo.py
@@ -1,4 +1,3 @@
-from typing import List
 from typing import Dict
 import sys
 import os
@@ -12,11 +11,11 @@ class ClusterInfo:
         self.name = name
         self.provision_host = ""
         self.network_api_port = ""
-        self.workers = []  # type: List[str]
-        self.bmcs = []  # type: List[str]
+        self.workers = []  # type: list[str]
+        self.bmcs = []  # type: list[str]
 
 
-def read_sheet() -> List[List[str]]:
+def read_sheet() -> list[list[str]]:
     logger.info("Downloading sheet from Google")
     scopes = ['https://www.googleapis.com/auth/spreadsheets', 'https://www.googleapis.com/auth/drive']
     cred_paths = [os.path.join(os.getcwd(), "credentials.json"), os.path.join(os.environ["HOME"], "credentials.json")]

--- a/clusterNode.py
+++ b/clusterNode.py
@@ -5,7 +5,7 @@ import sys
 import time
 from concurrent.futures import Future, ThreadPoolExecutor
 from logger import logger
-from typing import Optional, Tuple
+from typing import Optional
 
 import common
 import host
@@ -54,7 +54,7 @@ class ClusterNode:
         pass
 
     @abc.abstractmethod
-    def post_boot(self, desired_ip_range: Tuple[str, str]) -> bool:
+    def post_boot(self, desired_ip_range: tuple[str, str]) -> bool:
         pass
 
     def teardown(self) -> None:
@@ -166,7 +166,7 @@ class VmClusterNode(ClusterNode):
             return self.hostconn.vm_is_running(self.config.name)
         return self.future.done()
 
-    def post_boot(self, desired_ip_range: Tuple[str, str]) -> bool:
+    def post_boot(self, desired_ip_range: tuple[str, str]) -> bool:
         if not self.install_wait:
             self.future.result()
         return True
@@ -213,7 +213,7 @@ class X86ClusterNode(ClusterNode):
     def has_booted(self) -> bool:
         return self.future.done()
 
-    def post_boot(self, desired_ip_range: Tuple[str, str]) -> bool:
+    def post_boot(self, desired_ip_range: tuple[str, str]) -> bool:
         rh = host.RemoteHost(self.config.node)
         rh.ssh_connect("core")
         ipr_entries = common.ipa_to_entries(rh.run("ip -json a").out)
@@ -315,7 +315,7 @@ class BFClusterNode(ClusterNode):
     def has_booted(self) -> bool:
         return self.future.done()
 
-    def post_boot(self, desired_ip_range: Tuple[str, str]) -> bool:
+    def post_boot(self, desired_ip_range: tuple[str, str]) -> bool:
         result: Optional[host.Result] = self.future.result()
         if result is not None:
             self.dynamic_ip = result.out

--- a/clusterSnapshotter.py
+++ b/clusterSnapshotter.py
@@ -9,10 +9,9 @@ from logger import logger
 import coreosBuilder
 from concurrent.futures import ThreadPoolExecutor
 from nfs import NFS
-from typing import List
 
 
-def get_part_table(h: host.Host, drive: str) -> List[str]:
+def get_part_table(h: host.Host, drive: str) -> list[str]:
     fdisk_output = h.run(f"sudo fdisk -l {drive}").out.strip().split()
     parts = [x.split()[0] for x in fdisk_output if x.startswith(drive)]
     parts = [x for x in parts if ":" not in x]

--- a/clustersConfig.py
+++ b/clustersConfig.py
@@ -5,7 +5,6 @@ import io
 import sys
 import re
 from typing import Optional
-from typing import List
 from typing import Dict
 from typing import Tuple
 import jinja2
@@ -34,7 +33,7 @@ class ExtraConfigArgs:
     ovnk_rollout_timeout: str = "20m"
 
     kubeconfig: Optional[str] = None
-    mapping: Optional[List[Dict[str, str]]] = None
+    mapping: Optional[list[Dict[str, str]]] = None
 
     # Custom OVN build extra configs:
     # Time to wait for the builders to roll out.
@@ -128,18 +127,18 @@ class ClustersConfig:
     kind: str = "openshift"
     version: str = "4.14.0-nightly"
     network_api_port: str = "auto"
-    masters: List[NodeConfig] = []
-    workers: List[NodeConfig] = []
-    configured_workers: List[NodeConfig] = []
+    masters: list[NodeConfig] = []
+    workers: list[NodeConfig] = []
+    configured_workers: list[NodeConfig] = []
     local_bridge_config: BridgeConfig
     remote_bridge_config: BridgeConfig
     full_ip_range: Tuple[str, str]
     cluster_ip_range: Tuple[str, str]
-    hosts: List[HostConfig] = []
+    hosts: list[HostConfig] = []
     proxy: Optional[str] = None
     noproxy: Optional[str] = None
-    preconfig: List[ExtraConfigArgs] = []
-    postconfig: List[ExtraConfigArgs] = []
+    preconfig: list[ExtraConfigArgs] = []
+    postconfig: list[ExtraConfigArgs] = []
     ntp_source: str = "clock.redhat.com"
     base_dns_domain: str = "redhat.com"
 
@@ -344,22 +343,22 @@ class ClustersConfig:
     # def __setitem__(self, key, value) -> None:
     #     self.fullConfig[key] = value
 
-    def all_nodes(self) -> List[NodeConfig]:
+    def all_nodes(self) -> list[NodeConfig]:
         return self.masters + self.workers
 
-    def all_vms(self) -> List[NodeConfig]:
+    def all_vms(self) -> list[NodeConfig]:
         return [x for x in self.all_nodes() if x.kind == "vm"]
 
-    def worker_vms(self) -> List[NodeConfig]:
+    def worker_vms(self) -> list[NodeConfig]:
         return [x for x in self.workers if x.kind == "vm"]
 
-    def master_vms(self) -> List[NodeConfig]:
+    def master_vms(self) -> list[NodeConfig]:
         return [x for x in self.masters if x.kind == "vm"]
 
-    def local_vms(self) -> List[NodeConfig]:
+    def local_vms(self) -> list[NodeConfig]:
         return [x for x in self.all_vms() if x.node == "localhost"]
 
-    def local_worker_vms(self) -> List[NodeConfig]:
+    def local_worker_vms(self) -> list[NodeConfig]:
         return [x for x in self.worker_vms() if x.node == "localhost"]
 
     def is_sno(self) -> bool:

--- a/clustersConfig.py
+++ b/clustersConfig.py
@@ -5,7 +5,6 @@ import io
 import sys
 import re
 from typing import Optional
-from typing import Dict
 from typing import Tuple
 import jinja2
 from yaml import safe_load
@@ -33,7 +32,7 @@ class ExtraConfigArgs:
     ovnk_rollout_timeout: str = "20m"
 
     kubeconfig: Optional[str] = None
-    mapping: Optional[list[Dict[str, str]]] = None
+    mapping: Optional[list[dict[str, str]]] = None
 
     # Custom OVN build extra configs:
     # Time to wait for the builders to roll out.
@@ -121,8 +120,8 @@ def current_host() -> str:
 class ClustersConfig:
     name: str
     kubeconfig: str
-    api_vip: Dict[str, str]
-    ingress_vip: Dict[str, str]
+    api_vip: dict[str, str]
+    ingress_vip: dict[str, str]
     external_port: str = "auto"
     kind: str = "openshift"
     version: str = "4.14.0-nightly"
@@ -144,7 +143,7 @@ class ClustersConfig:
 
     # All configurations that used to be supported but are not anymore.
     # Used to warn the user to change their config.
-    deprecated_configs: Dict[str, Optional[str]] = {"api_ip": "api_vip", "ingress_ip": "ingress_vip"}
+    deprecated_configs: dict[str, Optional[str]] = {"api_ip": "api_vip", "ingress_ip": "ingress_vip"}
 
     def __init__(self, yaml_path: str, worker_range: common.RangeList):
         self._cluster_info: Optional[ClusterInfo] = None

--- a/clustersConfig.py
+++ b/clustersConfig.py
@@ -5,7 +5,6 @@ import io
 import sys
 import re
 from typing import Optional
-from typing import Tuple
 import jinja2
 from yaml import safe_load
 import host
@@ -108,7 +107,7 @@ class HostConfig:
 class BridgeConfig:
     ip: str
     mask: str
-    dynamic_ip_range: Optional[Tuple[str, str]] = None
+    dynamic_ip_range: Optional[tuple[str, str]] = None
 
 
 # Run the full hostname command
@@ -131,8 +130,8 @@ class ClustersConfig:
     configured_workers: list[NodeConfig] = []
     local_bridge_config: BridgeConfig
     remote_bridge_config: BridgeConfig
-    full_ip_range: Tuple[str, str]
-    cluster_ip_range: Tuple[str, str]
+    full_ip_range: tuple[str, str]
+    cluster_ip_range: tuple[str, str]
     hosts: list[HostConfig] = []
     proxy: Optional[str] = None
     noproxy: Optional[str] = None

--- a/common.py
+++ b/common.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 import ipaddress
-from typing import Optional, Set, Tuple, TypeVar, Iterator
+from typing import Optional, Set, TypeVar, Iterator
 import host
 import json
 import os
@@ -25,7 +25,7 @@ def str_to_list(input_str: str) -> list[int]:
 
 
 class RangeList:
-    _range: list[Tuple[bool, list[int]]] = []
+    _range: list[tuple[bool, list[int]]] = []
     initial_values: Optional[list[int]] = None
 
     def __init__(self, initial_values: Optional[list[int]] = None):
@@ -105,16 +105,16 @@ def ipr_to_entries(input: str) -> list[IPRouteRouteEntry]:
     return ret
 
 
-def ip_range(start_addr: str, n_addrs: int) -> Tuple[str, str]:
+def ip_range(start_addr: str, n_addrs: int) -> tuple[str, str]:
     return start_addr, str(ipaddress.ip_address(start_addr) + n_addrs)
 
 
-def ip_range_contains(range: Tuple[str, str], ip: str) -> bool:
+def ip_range_contains(range: tuple[str, str], ip: str) -> bool:
     ip_val = ipaddress.IPv4Address(ip)
     return ipaddress.IPv4Address(range[0]) <= ip_val and ipaddress.IPv4Address(range[1]) > ip_val
 
 
-def ip_range_size(range: Tuple[str, str]) -> int:
+def ip_range_size(range: tuple[str, str]) -> int:
     return int(ipaddress.IPv4Address(range[1])) - int(ipaddress.IPv4Address(range[0]))
 
 
@@ -173,7 +173,7 @@ def get_auto_port(host: host.Host) -> str:
         return interfaces[0].ifname
 
 
-def iterate_ssh_keys() -> Iterator[Tuple[str, str, str]]:
+def iterate_ssh_keys() -> Iterator[tuple[str, str, str]]:
     for pub_file in glob.glob("/root/.ssh/*.pub"):
         with open(pub_file, 'r') as f:
             pub_key_content = f.read().strip()

--- a/common.py
+++ b/common.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 import ipaddress
-from typing import List, Optional, Set, Tuple, TypeVar, Iterator
+from typing import Optional, Set, Tuple, TypeVar, Iterator
 import host
 import json
 import os
@@ -10,7 +10,7 @@ import glob
 T = TypeVar("T")
 
 
-def str_to_list(input_str: str) -> List[int]:
+def str_to_list(input_str: str) -> list[int]:
     result: Set[int] = set()
     parts = input_str.split(',')
 
@@ -25,22 +25,22 @@ def str_to_list(input_str: str) -> List[int]:
 
 
 class RangeList:
-    _range: List[Tuple[bool, List[int]]] = []
-    initial_values: Optional[List[int]] = None
+    _range: list[Tuple[bool, list[int]]] = []
+    initial_values: Optional[list[int]] = None
 
-    def __init__(self, initial_values: Optional[List[int]] = None):
+    def __init__(self, initial_values: Optional[list[int]] = None):
         self.initial_values = initial_values
 
-    def _append(self, lst: List[int], expand: bool) -> None:
+    def _append(self, lst: list[int], expand: bool) -> None:
         self._range.append((expand, lst))
 
-    def include(self, lst: List[int]) -> None:
+    def include(self, lst: list[int]) -> None:
         self._append(lst, True)
 
-    def exclude(self, lst: List[int]) -> None:
+    def exclude(self, lst: list[int]) -> None:
         self._append(lst, False)
 
-    def filter_list(self, initial: List[T]) -> List[T]:
+    def filter_list(self, initial: list[T]) -> list[T]:
         applied = set(range(len(initial)))
         if self.initial_values is not None:
             applied &= set(self.initial_values)
@@ -63,19 +63,19 @@ class IPRouteAddressInfoEntry:
 class IPRouteAddressEntry:
     ifindex: int
     ifname: str
-    flags: List[str]
+    flags: list[str]
     master: Optional[str]
     address: str  # Ethernet address.
-    addr_info: List[IPRouteAddressInfoEntry]
+    addr_info: list[IPRouteAddressInfoEntry]
 
 
 def ipa(host: host.Host) -> str:
     return host.run("ip -json a").out
 
 
-def ipa_to_entries(input: str) -> List[IPRouteAddressEntry]:
+def ipa_to_entries(input: str) -> list[IPRouteAddressEntry]:
     j = json.loads(input)
-    ret: List[IPRouteAddressEntry] = []
+    ret: list[IPRouteAddressEntry] = []
     for e in j:
         addr_infos = []
         for addr in e["addr_info"]:
@@ -97,9 +97,9 @@ class IPRouteRouteEntry:
     dev: str
 
 
-def ipr_to_entries(input: str) -> List[IPRouteRouteEntry]:
+def ipr_to_entries(input: str) -> list[IPRouteRouteEntry]:
     j = json.loads(input)
-    ret: List[IPRouteRouteEntry] = []
+    ret: list[IPRouteRouteEntry] = []
     for e in j:
         ret.append(IPRouteRouteEntry(e["dst"], e["dev"]))
     return ret
@@ -122,7 +122,7 @@ def ip_in_subnet(addr: str, subnet: str) -> bool:
     return ipaddress.ip_address(addr) in ipaddress.ip_network(subnet)
 
 
-def extract_interfaces(input: str) -> List[str]:
+def extract_interfaces(input: str) -> list[str]:
     entries = ipa_to_entries(input)
     return [x.ifname for x in entries]
 
@@ -156,7 +156,7 @@ def port_to_ip(host: host.Host, port_name: str) -> Optional[str]:
     return None
 
 
-def carrier_no_addr(host: host.Host) -> List[IPRouteAddressEntry]:
+def carrier_no_addr(host: host.Host) -> list[IPRouteAddressEntry]:
     def carrier_no_addr(intf: IPRouteAddressEntry) -> bool:
         return len(intf.addr_info) == 0 and "NO-CARRIER" not in intf.flags
 

--- a/common.py
+++ b/common.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 import ipaddress
-from typing import Optional, Set, TypeVar, Iterator
+from typing import Optional, TypeVar, Iterator
 import host
 import json
 import os
@@ -11,7 +11,7 @@ T = TypeVar("T")
 
 
 def str_to_list(input_str: str) -> list[int]:
-    result: Set[int] = set()
+    result: set[int] = set()
     parts = input_str.split(',')
 
     for part in parts:

--- a/extraConfigBFB.py
+++ b/extraConfigBFB.py
@@ -5,7 +5,7 @@ from concurrent.futures import ThreadPoolExecutor
 from k8sClient import K8sClient
 from nfs import NFS
 from concurrent.futures import Future
-from typing import Dict, Optional
+from typing import Optional
 import sys
 from logger import logger
 from clustersConfig import ExtraConfigArgs
@@ -27,7 +27,7 @@ to be in a good state.
 """
 
 
-def ExtraConfigBFB(cc: ClustersConfig, _: ExtraConfigArgs, futures: Dict[str, Future[Optional[host.Result]]]) -> None:
+def ExtraConfigBFB(cc: ClustersConfig, _: ExtraConfigArgs, futures: dict[str, Future[Optional[host.Result]]]) -> None:
     coreosBuilder.ensure_fcos_exists()
     logger.info("Loading BF-2 with BFB image on all workers")
     lh = host.LocalHost()
@@ -62,7 +62,7 @@ def ExtraConfigBFB(cc: ClustersConfig, _: ExtraConfigArgs, futures: Dict[str, Fu
     logger.info("BFB setup complete")
 
 
-def ExtraConfigSwitchNicMode(cc: ClustersConfig, _: ExtraConfigArgs, futures: Dict[str, Future[Optional[host.Result]]]) -> None:
+def ExtraConfigSwitchNicMode(cc: ClustersConfig, _: ExtraConfigArgs, futures: dict[str, Future[Optional[host.Result]]]) -> None:
     [f.result() for (_, f) in futures.items()]
     client = K8sClient(cc.kubeconfig)
 

--- a/extraConfigCNO.py
+++ b/extraConfigCNO.py
@@ -3,13 +3,13 @@ from k8sClient import K8sClient
 from configOperators import ConfigCVO
 import sys
 from concurrent.futures import Future
-from typing import Dict, Optional
+from typing import Optional
 from logger import logger
 from clustersConfig import ExtraConfigArgs
 import host
 
 
-def ExtraConfigCNO(cc: ClustersConfig, cfg: ExtraConfigArgs, futures: Dict[str, Future[Optional[host.Result]]]) -> None:
+def ExtraConfigCNO(cc: ClustersConfig, cfg: ExtraConfigArgs, futures: dict[str, Future[Optional[host.Result]]]) -> None:
     [f.result() for (_, f) in futures.items()]
     logger.info("Running post config step to load custom CNO")
     iclient = K8sClient(cc.kubeconfig)

--- a/extraConfigCX.py
+++ b/extraConfigCX.py
@@ -4,7 +4,7 @@ import coreosBuilder
 from concurrent.futures import ThreadPoolExecutor
 from nfs import NFS
 from concurrent.futures import Future
-from typing import Dict, Optional
+from typing import Optional
 import sys
 from logger import logger
 from clustersConfig import ExtraConfigArgs
@@ -21,7 +21,7 @@ tools available. https://github.com/bn222/dpu-tools/
 """
 
 
-def ExtraConfigCX(cc: ClustersConfig, _: ExtraConfigArgs, futures: Dict[str, Future[Optional[host.Result]]]) -> None:
+def ExtraConfigCX(cc: ClustersConfig, _: ExtraConfigArgs, futures: dict[str, Future[Optional[host.Result]]]) -> None:
     coreosBuilder.ensure_fcos_exists()
     logger.info("Updating CX firmware on all workers")
     lh = host.LocalHost()

--- a/extraConfigCustomOvn.py
+++ b/extraConfigCustomOvn.py
@@ -1,13 +1,13 @@
 from clustersConfig import ClustersConfig
 from k8sClient import K8sClient
 from concurrent.futures import Future
-from typing import Dict, Optional
+from typing import Optional
 from logger import logger
 from clustersConfig import ExtraConfigArgs
 import host
 
 
-def ExtraConfigCustomOvn(cc: ClustersConfig, cfg: ExtraConfigArgs, futures: Dict[str, Future[Optional[host.Result]]]) -> None:
+def ExtraConfigCustomOvn(cc: ClustersConfig, cfg: ExtraConfigArgs, futures: dict[str, Future[Optional[host.Result]]]) -> None:
     [f.result() for (_, f) in futures.items()]
     logger.info("Running post config step to build custom OVN from source")
     iclient = K8sClient(cc.kubeconfig)

--- a/extraConfigDpuInfra.py
+++ b/extraConfigDpuInfra.py
@@ -10,7 +10,6 @@ import os
 import sys
 import shutil
 from common_patches import apply_common_pathches
-from typing import Dict
 from typing import Optional
 from logger import logger
 from clustersConfig import ExtraConfigArgs
@@ -139,7 +138,7 @@ def restart_ovs_configuration(ips: list[str]) -> None:
         rh.run("sudo systemctl restart ovs-configuration")
 
 
-def _ExtraConfigDpuInfra_common(cc: ClustersConfig, futures: Dict[str, Future[Optional[host.Result]]], *, new_api: bool) -> None:
+def _ExtraConfigDpuInfra_common(cc: ClustersConfig, futures: dict[str, Future[Optional[host.Result]]], *, new_api: bool) -> None:
     [f.result() for (_, f) in futures.items()]
     kc = "/root/kubeconfig.infracluster"
     client = K8sClient(kc)
@@ -224,12 +223,12 @@ def _ExtraConfigDpuInfra_common(cc: ClustersConfig, futures: Dict[str, Future[Op
             sys.exit(-1)
 
 
-def ExtraConfigDpuInfra(cc: ClustersConfig, _: ExtraConfigArgs, futures: Dict[str, Future[Optional[host.Result]]]) -> None:
+def ExtraConfigDpuInfra(cc: ClustersConfig, _: ExtraConfigArgs, futures: dict[str, Future[Optional[host.Result]]]) -> None:
     _ExtraConfigDpuInfra_common(cc, futures, new_api=False)
 
 
 # VF Management port requires a new API. We need a new extra config class to handle the API changes.
-def ExtraConfigDpuInfra_NewAPI(cc: ClustersConfig, _: ExtraConfigArgs, futures: Dict[str, Future[Optional[host.Result]]]) -> None:
+def ExtraConfigDpuInfra_NewAPI(cc: ClustersConfig, _: ExtraConfigArgs, futures: dict[str, Future[Optional[host.Result]]]) -> None:
     _ExtraConfigDpuInfra_common(cc, futures, new_api=True)
 
 

--- a/extraConfigDpuInfra.py
+++ b/extraConfigDpuInfra.py
@@ -11,13 +11,12 @@ import sys
 import shutil
 from common_patches import apply_common_pathches
 from typing import Dict
-from typing import List
 from typing import Optional
 from logger import logger
 from clustersConfig import ExtraConfigArgs
 
 
-def install_remotely(ip: str, links: List[str]) -> bool:
+def install_remotely(ip: str, links: list[str]) -> bool:
     try:
         return install_remotelyh(ip, links)
     except Exception as e:
@@ -25,7 +24,7 @@ def install_remotely(ip: str, links: List[str]) -> bool:
     return False
 
 
-def install_remotelyh(ip: str, links: List[str]) -> bool:
+def install_remotelyh(ip: str, links: list[str]) -> bool:
     logger.info(f"connecting to {ip}")
     rh = host.RemoteHost(ip)
     # Eventhough a buggy kernel can cause connections to drop,
@@ -67,7 +66,7 @@ def install_remotelyh(ip: str, links: List[str]) -> bool:
     return want in rh.run("uname -a").out
 
 
-def install_custom_kernel(lh: host.Host, client: K8sClient, bf_names: List[str], ips: List[str]) -> None:
+def install_custom_kernel(lh: host.Host, client: K8sClient, bf_names: list[str], ips: list[str]) -> None:
     logger.info(f"Installing custom kernel on {ips}")
     links = [
         "https://s3.upshift.redhat.com/DH-PROD-CKI/internal-artifacts/696717272/build%20aarch64/3333360250/artifacts/kernel-core-4.18.0-372.35.1.el8_6.mr3440_221116_1544.aarch64.rpm",
@@ -131,7 +130,7 @@ def run_dpu_network_operator_git(lh: host.Host, kc: str) -> None:
     os.chdir(cur_dir)
 
 
-def restart_ovs_configuration(ips: List[str]) -> None:
+def restart_ovs_configuration(ips: list[str]) -> None:
     logger.info("Restarting ovs config")
 
     for ip in ips:

--- a/extraConfigDpuTenant.py
+++ b/extraConfigDpuTenant.py
@@ -5,7 +5,6 @@ from common_patches import apply_common_pathches
 from concurrent.futures import Future
 from extraConfigDpuInfra import run_dpu_network_operator_git
 import extraConfigSriov
-from typing import Dict
 from typing import Optional
 import sys
 import jinja2
@@ -16,7 +15,7 @@ from logger import logger
 from clustersConfig import ExtraConfigArgs
 
 
-def ExtraConfigDpuTenantMC(cc: ClustersConfig, _: ExtraConfigArgs, futures: Dict[str, Future[Optional[host.Result]]]) -> None:
+def ExtraConfigDpuTenantMC(cc: ClustersConfig, _: ExtraConfigArgs, futures: dict[str, Future[Optional[host.Result]]]) -> None:
     [f.result() for (_, f) in futures.items()]
     logger.info("Running post config step")
     tclient = K8sClient("/root/kubeconfig.tenantcluster")
@@ -48,13 +47,13 @@ def render_sriov_node_policy(policyname: str, bf_port: str, bf_addr: str, numvfs
         outFile.write(rendered)
 
 
-def render_envoverrides_cm(client: K8sClient, mapping: Optional[list[Dict[str, str]]], ns: str) -> str:
+def render_envoverrides_cm(client: K8sClient, mapping: Optional[list[dict[str, str]]], ns: str) -> str:
     assert mapping is not None
     contents = open("manifests/tenant/envoverrides.yaml").read()
     contents += f"{ns}\n"
     contents += "data:\n"
     for e in mapping:
-        a: Dict[str, str] = {}
+        a: dict[str, str] = {}
         a["TENANT_K8S_NODE"] = e["worker"]
         # Can be removed since API is replaced https://github.com/openshift/dpu-network-operator/pull/67
         dpu_ip = client.get_ip(e["bf"])
@@ -72,7 +71,7 @@ def render_envoverrides_cm(client: K8sClient, mapping: Optional[list[Dict[str, s
     return f"/tmp/envoverrides-{ns}.yaml"
 
 
-def _ExtraConfigDpuTenant_common(cc: ClustersConfig, cfg: ExtraConfigArgs, futures: Dict[str, Future[Optional[host.Result]]], *, new_api: bool = False) -> None:
+def _ExtraConfigDpuTenant_common(cc: ClustersConfig, cfg: ExtraConfigArgs, futures: dict[str, Future[Optional[host.Result]]], *, new_api: bool = False) -> None:
     [f.result() for (_, f) in futures.items()]
     logger.info("Running post config step")
 
@@ -177,7 +176,7 @@ def _ExtraConfigDpuTenant_common(cc: ClustersConfig, cfg: ExtraConfigArgs, futur
 
         assert cfg.mapping is not None
         for bfmap in cfg.mapping:
-            a: Dict[str, str] = {}
+            a: dict[str, str] = {}
             mp = re.sub(r'np\d$', '', bf_port)
             a["OVNKUBE_NODE_MGMT_PORT_NETDEV"] = f"{mp}v0"
             contents += f"  {bfmap['worker']}: |\n"
@@ -256,11 +255,11 @@ def _ExtraConfigDpuTenant_common(cc: ClustersConfig, cfg: ExtraConfigArgs, futur
     extraConfigSriov.ensure_pci_realloc(cc, tclient, "dpu-host")
 
 
-def ExtraConfigDpuTenant(cc: ClustersConfig, cfg: ExtraConfigArgs, futures: Dict[str, Future[Optional[host.Result]]]) -> None:
+def ExtraConfigDpuTenant(cc: ClustersConfig, cfg: ExtraConfigArgs, futures: dict[str, Future[Optional[host.Result]]]) -> None:
     _ExtraConfigDpuTenant_common(cc, cfg, futures, new_api=False)
 
 
-def ExtraConfigDpuTenant_NewAPI(cc: ClustersConfig, cfg: ExtraConfigArgs, futures: Dict[str, Future[Optional[host.Result]]]) -> None:
+def ExtraConfigDpuTenant_NewAPI(cc: ClustersConfig, cfg: ExtraConfigArgs, futures: dict[str, Future[Optional[host.Result]]]) -> None:
     _ExtraConfigDpuTenant_common(cc, cfg, futures, new_api=True)
 
 

--- a/extraConfigDpuTenant.py
+++ b/extraConfigDpuTenant.py
@@ -6,7 +6,6 @@ from concurrent.futures import Future
 from extraConfigDpuInfra import run_dpu_network_operator_git
 import extraConfigSriov
 from typing import Dict
-from typing import List
 from typing import Optional
 import sys
 import jinja2
@@ -49,7 +48,7 @@ def render_sriov_node_policy(policyname: str, bf_port: str, bf_addr: str, numvfs
         outFile.write(rendered)
 
 
-def render_envoverrides_cm(client: K8sClient, mapping: Optional[List[Dict[str, str]]], ns: str) -> str:
+def render_envoverrides_cm(client: K8sClient, mapping: Optional[list[Dict[str, str]]], ns: str) -> str:
     assert mapping is not None
     contents = open("manifests/tenant/envoverrides.yaml").read()
     contents += f"{ns}\n"

--- a/extraConfigDualStack.py
+++ b/extraConfigDualStack.py
@@ -1,5 +1,5 @@
 from concurrent.futures import Future
-from typing import Dict, Optional
+from typing import Optional
 from clustersConfig import ClustersConfig
 from logger import logger
 from k8sClient import K8sClient
@@ -7,7 +7,7 @@ from clustersConfig import ExtraConfigArgs
 import host
 
 
-def ExtraConfigDualStack(cc: ClustersConfig, _: ExtraConfigArgs, futures: Dict[str, Future[Optional[host.Result]]]) -> None:
+def ExtraConfigDualStack(cc: ClustersConfig, _: ExtraConfigArgs, futures: dict[str, Future[Optional[host.Result]]]) -> None:
     # https://docs.openshift.com/container-platform/4.13/networking/ovn_kubernetes_network_provider/converting-to-dual-stack.html
     # https://issues.redhat.com/browse/OCPBUGS-6040
     [f.result() for (_, f) in futures.items()]

--- a/extraConfigOvnK.py
+++ b/extraConfigOvnK.py
@@ -3,13 +3,13 @@ from k8sClient import K8sClient
 from configOperators import ConfigCVO
 import sys
 from concurrent.futures import Future
-from typing import Dict, Optional
+from typing import Optional
 from logger import logger
 from clustersConfig import ExtraConfigArgs
 import host
 
 
-def ExtraConfigOvnK(cc: ClustersConfig, cfg: ExtraConfigArgs, futures: Dict[str, Future[Optional[host.Result]]]) -> None:
+def ExtraConfigOvnK(cc: ClustersConfig, cfg: ExtraConfigArgs, futures: dict[str, Future[Optional[host.Result]]]) -> None:
     [f.result() for (_, f) in futures.items()]
     logger.info("Running post config step to load custom OVN-K")
     iclient = K8sClient(cc.kubeconfig)

--- a/extraConfigRT.py
+++ b/extraConfigRT.py
@@ -2,12 +2,12 @@ from clustersConfig import ClustersConfig
 from k8sClient import K8sClient
 from logger import logger
 from concurrent.futures import Future
-from typing import Dict, Optional
+from typing import Optional
 from clustersConfig import ExtraConfigArgs
 import host
 
 
-def ExtraConfigRT(cc: ClustersConfig, _: ExtraConfigArgs, futures: Dict[str, Future[Optional[host.Result]]]) -> None:
+def ExtraConfigRT(cc: ClustersConfig, _: ExtraConfigArgs, futures: dict[str, Future[Optional[host.Result]]]) -> None:
     [f.result() for (_, f) in futures.items()]
 
     is_sno = cc.is_sno()

--- a/extraConfigRunner.py
+++ b/extraConfigRunner.py
@@ -11,7 +11,7 @@ from extraConfigCX import ExtraConfigCX
 from clustersConfig import ClustersConfig
 from clustersConfig import ExtraConfigArgs
 from concurrent.futures import Future
-from typing import Callable, Dict, Optional
+from typing import Callable, Optional
 from logger import logger
 import sys
 import host
@@ -20,7 +20,7 @@ import host
 class ExtraConfigRunner:
     def __init__(self, cc: ClustersConfig):
         self._cc = cc
-        self._extra_config: Dict[str, Callable[[ClustersConfig, ExtraConfigArgs, Dict[str, Future[Optional[host.Result]]]], None]] = {
+        self._extra_config: dict[str, Callable[[ClustersConfig, ExtraConfigArgs, dict[str, Future[Optional[host.Result]]]], None]] = {
             "bf_bfb_image": ExtraConfigBFB,
             "switch_to_nic_mode": ExtraConfigSwitchNicMode,
             "sriov_network_operator": ExtraConfigSriov,
@@ -40,7 +40,7 @@ class ExtraConfigRunner:
             "cx_firmware": ExtraConfigCX,
         }
 
-    def run(self, to_run: ExtraConfigArgs, futures: Dict[str, Future[Optional[host.Result]]]) -> None:
+    def run(self, to_run: ExtraConfigArgs, futures: dict[str, Future[Optional[host.Result]]]) -> None:
         if to_run.name not in self._extra_config:
             logger.info(f"{to_run.name} is not an extra config")
             sys.exit(-1)

--- a/extraConfigSriov.py
+++ b/extraConfigSriov.py
@@ -9,7 +9,6 @@ import shutil
 import jinja2
 import sys
 from typing import Dict
-from typing import List
 from typing import Optional
 from logger import logger
 from clustersConfig import ExtraConfigArgs
@@ -110,7 +109,7 @@ def ensure_pci_realloc(cc: ClustersConfig, client: K8sClient, mcp_name: str) -> 
         enable_pci_realloc(client, mcp_name)
 
 
-def render_sriov_node_policy(policyname: str, pfnames: List[str], numvfs: int, resourcename: str, outfilename: str) -> None:
+def render_sriov_node_policy(policyname: str, pfnames: list[str], numvfs: int, resourcename: str, outfilename: str) -> None:
     with open('./manifests/nicmode/sriov-node-policy.yaml.j2') as f:
         j2_template = jinja2.Template(f.read())
         rendered = j2_template.render(policyName=policyname, pfNamesAll=pfnames, numVfs=numvfs, resourceName=resourcename)

--- a/extraConfigSriov.py
+++ b/extraConfigSriov.py
@@ -8,13 +8,12 @@ from concurrent.futures import Future
 import shutil
 import jinja2
 import sys
-from typing import Dict
 from typing import Optional
 from logger import logger
 from clustersConfig import ExtraConfigArgs
 
 
-def ExtraConfigSriov(cc: ClustersConfig, cfg: ExtraConfigArgs, futures: Dict[str, Future[Optional[host.Result]]]) -> None:
+def ExtraConfigSriov(cc: ClustersConfig, cfg: ExtraConfigArgs, futures: dict[str, Future[Optional[host.Result]]]) -> None:
     [f.result() for (_, f) in futures.items()]
     client = K8sClient(cc.kubeconfig)
     lh = host.LocalHost()
@@ -55,7 +54,7 @@ def ExtraConfigSriov(cc: ClustersConfig, cfg: ExtraConfigArgs, futures: Dict[str
     client.oc("apply -f manifests/nicmode/sriov-operator-config.yaml")
 
 
-def ExtraConfigSriovSubscription(cc: ClustersConfig, cfg: ExtraConfigArgs, futures: Dict[str, Future[Optional[host.Result]]]) -> None:
+def ExtraConfigSriovSubscription(cc: ClustersConfig, cfg: ExtraConfigArgs, futures: dict[str, Future[Optional[host.Result]]]) -> None:
     [f.result() for (_, f) in futures.items()]
     client = K8sClient(cc.kubeconfig)
     lh = host.LocalHost()
@@ -142,7 +141,7 @@ def try_get_ovs_pf(rh: host.Host, name: str) -> str:
     sys.exit(-1)
 
 
-def _ExtraConfigSriovOvSHWOL_common(cc: ClustersConfig, futures: Dict[str, Future[Optional[host.Result]]], *, new_api: bool) -> None:
+def _ExtraConfigSriovOvSHWOL_common(cc: ClustersConfig, futures: dict[str, Future[Optional[host.Result]]], *, new_api: bool) -> None:
     [f.result() for (_, f) in futures.items()]
     client = K8sClient(cc.kubeconfig)
     client.oc("create -f manifests/nicmode/pool.yaml")
@@ -210,12 +209,12 @@ def _ExtraConfigSriovOvSHWOL_common(cc: ClustersConfig, futures: Dict[str, Futur
     ensure_pci_realloc(cc, client, "sriov")
 
 
-def ExtraConfigSriovOvSHWOL(cc: ClustersConfig, _: ExtraConfigArgs, futures: Dict[str, Future[Optional[host.Result]]]) -> None:
+def ExtraConfigSriovOvSHWOL(cc: ClustersConfig, _: ExtraConfigArgs, futures: dict[str, Future[Optional[host.Result]]]) -> None:
     _ExtraConfigSriovOvSHWOL_common(cc, futures, new_api=False)
 
 
 # VF Management port requires a new API. We need a new extra config class to handle the API changes.
-def ExtraConfigSriovOvSHWOL_NewAPI(cc: ClustersConfig, _: ExtraConfigArgs, futures: Dict[str, Future[Optional[host.Result]]]) -> None:
+def ExtraConfigSriovOvSHWOL_NewAPI(cc: ClustersConfig, _: ExtraConfigArgs, futures: dict[str, Future[Optional[host.Result]]]) -> None:
     _ExtraConfigSriovOvSHWOL_common(cc, futures, new_api=True)
 
 

--- a/host.py
+++ b/host.py
@@ -12,7 +12,6 @@ import logging
 import tempfile
 from typing import Optional
 from typing import Union
-from typing import List
 from typing import Type
 from typing import Any
 from typing import Dict
@@ -208,7 +207,7 @@ class Host:
     def __init__(self, hostname: str, bmc: Optional[BMC] = None):
         self._hostname = hostname
         self._bmc = bmc
-        self._logins: List[Login] = []
+        self._logins: list[Login] = []
         self.sudo_needed = False
 
     @lru_cache(maxsize=None)
@@ -242,7 +241,7 @@ class Host:
 
         self.ssh_connect_looped(self._logins)
 
-    def ssh_connect_looped(self, logins: List[Login]) -> None:
+    def ssh_connect_looped(self, logins: list[Login]) -> None:
         if len(logins) == 0:
             raise Exception("No usuable logins found")
         while True:
@@ -456,7 +455,7 @@ class Host:
                 return ret.out
             raise Exception(f"Error reading {file_name}")
 
-    def listdir(self, path: Optional[str] = None) -> List[str]:
+    def listdir(self, path: Optional[str] = None) -> list[str]:
         if self.is_localhost():
             return os.listdir(path)
         path = path if path is not None else ""
@@ -520,7 +519,7 @@ class HostWithBF2(Host):
             logger.log(log_level, f"{self._hostname} -> BF: {line.strip()}")
             out.append(line)
 
-        err: List[str] = []
+        err: list[str] = []
         for line in iter(stderr.readline, ""):
             err.append(line)
 

--- a/host.py
+++ b/host.py
@@ -14,7 +14,6 @@ from typing import Optional
 from typing import Union
 from typing import Type
 from typing import Any
-from typing import Tuple
 from functools import lru_cache
 from ailib import Redfish
 import paramiko
@@ -565,7 +564,7 @@ class HostWithBF2(Host):
         return self.run_in_container("/bfb")
 
 
-host_instances: dict[Tuple[str, Optional[str]], Host] = {}
+host_instances: dict[tuple[str, Optional[str]], Host] = {}
 
 
 def sync_time(src: Host, dst: Host) -> Result:

--- a/host.py
+++ b/host.py
@@ -12,7 +12,6 @@ import logging
 import tempfile
 from typing import Optional
 from typing import Union
-from typing import Type
 from typing import Any
 from functools import lru_cache
 from ailib import Redfish
@@ -57,7 +56,7 @@ class KeyLogin(Login):
         key_loader = self._key_loader()
         self._pkey = key_loader.from_private_key(io.StringIO(self._key))
 
-    def _key_loader(self) -> Union[Type[Ed25519Key], Type[RSAKey]]:
+    def _key_loader(self) -> Union[type[Ed25519Key], type[RSAKey]]:
         if self._is_rsa():
             return RSAKey
         else:

--- a/host.py
+++ b/host.py
@@ -14,7 +14,6 @@ from typing import Optional
 from typing import Union
 from typing import Type
 from typing import Any
-from typing import Dict
 from typing import Tuple
 from functools import lru_cache
 from ailib import Redfish
@@ -294,7 +293,7 @@ class Host:
     def need_sudo(self) -> None:
         self.sudo_needed = True
 
-    def run(self, cmd: str, log_level: int = logging.DEBUG, env: Dict[str, str] = os.environ.copy()) -> Result:
+    def run(self, cmd: str, log_level: int = logging.DEBUG, env: dict[str, str] = os.environ.copy()) -> Result:
         if self.sudo_needed:
             cmd = "sudo " + cmd
 
@@ -307,7 +306,7 @@ class Host:
         logger.log(log_level, ret_val)
         return ret_val
 
-    def _run_local(self, cmd: str, env: Dict[str, str]) -> Result:
+    def _run_local(self, cmd: str, env: dict[str, str]) -> Result:
         args = shlex.split(cmd)
         pipe = subprocess.PIPE
         with subprocess.Popen(args, stdout=pipe, stderr=pipe, env=env) as proc:
@@ -394,7 +393,7 @@ class Host:
         r = lh.run(ping_cmd)
         return r.returncode == 0
 
-    def os_release(self) -> Dict[str, str]:
+    def os_release(self) -> dict[str, str]:
         d = {}
         for e in self.read_file("/etc/os-release").split("\n"):
             split_e = e.split("=", maxsplit=1)
@@ -566,7 +565,7 @@ class HostWithBF2(Host):
         return self.run_in_container("/bfb")
 
 
-host_instances: Dict[Tuple[str, Optional[str]], Host] = {}
+host_instances: dict[Tuple[str, Optional[str]], Host] = {}
 
 
 def sync_time(src: Host, dst: Host) -> Result:

--- a/k8sClient.py
+++ b/k8sClient.py
@@ -3,7 +3,6 @@ import yaml
 import time
 import host
 import sys
-from typing import List
 from typing import Optional
 from typing import Callable
 from logger import logger
@@ -27,7 +26,7 @@ class K8sClient:
                         return str(con.status) == "True"
         return False
 
-    def get_nodes(self) -> List[str]:
+    def get_nodes(self) -> list[str]:
         return [e.metadata.name for e in self._client.list_node().items]
 
     def wait_ready(self, name: str, cb: Optional[Callable[[], None]] = None) -> None:

--- a/virtualBridge.py
+++ b/virtualBridge.py
@@ -3,14 +3,14 @@ import re
 import sys
 import time
 from logger import logger
-from typing import Optional, Tuple
+from typing import Optional
 
 import common
 import host
 from clustersConfig import BridgeConfig, NodeConfig
 
 
-def bridge_dhcp_range_str(dhcp_range: Optional[Tuple[str, str]]) -> str:
+def bridge_dhcp_range_str(dhcp_range: Optional[tuple[str, str]]) -> str:
     if dhcp_range is not None:
         return f"<range start='{dhcp_range[0]}' end='{dhcp_range[1]}'/>"
     return ""


### PR DESCRIPTION
Since Python 3.9, the standard collections support being used as generic types.

CDA depends on Python 3.10.

See https://docs.python.org/3/library/typing.html#typing.List:

> Deprecated since version 3.9: builtins.list now supports subscripting ([]). See [PEP 585](https://peps.python.org/pep-0585/) and [Generic Alias Type](https://docs.python.org/3/library/stdtypes.html#types-genericalias).