### PR TITLE
[th/flake8-no-e203] flake8: ignore "E203 whitespace before :" warning

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,6 @@
 [flake8]
 extend-ignore =
+    E203
     E501
 extend-exclude =
     *venv/


### PR DESCRIPTION
We format the code with python-black. flake8 also does some style checking, and in cases where they disagree, black is correct.

You can hit this easily with
```
    str = "somestring"
    assert str[len("some") :] == "string"
```
https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#e203