### PR TITLE
[th/ensure-virsh-pool] ensure libvirt storage pool exists to avoid failure of virt-install

### DIFF
--- a/clusterDeployer.py
+++ b/clusterDeployer.py
@@ -23,6 +23,7 @@ import microshift
 from extraConfigRunner import ExtraConfigRunner
 from clusterHost import ClusterHost
 import dnsutil
+from virshPool import VirshPool
 
 
 def match_to_proper_version_format(version_cluster_config: str) -> str:
@@ -153,6 +154,14 @@ class ClusterDeployer:
                 f.write(json.dumps(filtered, indent=4))
             logger.info(self._local_host.hostconn.run("virsh net-start default"))
             logger.info(self._local_host.hostconn.run("systemctl restart libvirtd"))
+
+            image_paths = {os.path.dirname(n.image_path) for n in self._cc.local_vms()}
+            for image_path in image_paths:
+                vp = VirshPool(
+                    name=os.path.basename(image_path),
+                    rsh=self._local_host.hostconn,
+                )
+                vp.ensure_removed()
 
         for h in self._all_hosts:
             h.ensure_not_linked_to_network()

--- a/clusterDeployer.py
+++ b/clusterDeployer.py
@@ -201,7 +201,9 @@ class ClusterDeployer:
                     if len(self._cc.workers) != 0:
                         self.create_workers()
                     else:
-                        logger.info("Skipping worker creation.")
+                        logger.info("No worker to setup. Skip")
+                else:
+                    logger.info("Skipping worker creation.")
         if self._cc.kind == "microshift":
             version = match_to_proper_version_format(self._cc.version)
 

--- a/virshPool.py
+++ b/virshPool.py
@@ -1,0 +1,47 @@
+from dataclasses import dataclass
+from typing import Optional
+
+import host
+from logger import logger
+
+
+@dataclass(frozen=True)
+class VirshPool:
+    name: str
+    rsh: host.Host
+    image_path: Optional[str] = None
+
+    def __str__(self) -> str:
+        return f"{self.name}@{self.rsh.hostname()}"
+
+    def rsh_run(self, cmd: str) -> host.Result:
+        return self.rsh.run(cmd)
+
+    def initialized(self) -> bool:
+        cmd = f"virsh pool-info {self.name}"
+        return self.rsh_run(cmd).success()
+
+    def ensure_initialized(self) -> None:
+        if not self.initialized():
+            self.initialize()
+        else:
+            logger.info(f"virsh-pool[{self}]: Pool {self.name} already initialized (image-path={self.image_path})")
+
+    def initialize(self) -> None:
+        if not self.image_path:
+            raise RuntimeError("The VirshPool is created without an image path and cannot be initialized")
+
+        logger.info(f"virsh-pool[{self}]: Initializing pool {self.name} at {self.image_path}")
+        self.rsh_run(f"virsh pool-define-as {self.name} dir - - - - {self.image_path}")
+        self.rsh_run(f"mkdir -p {self.image_path}")
+        self.rsh_run(f"chmod a+rw {self.image_path}")
+        self.rsh_run(f"virsh pool-start {self.name}")
+        logger.info(f"virsh-pool[{self}]: Pool initialized")
+
+    def ensure_removed(self) -> None:
+        if self.initialized():
+            self.remove()
+
+    def remove(self) -> None:
+        self.rsh_run(f"virsh pool-destroy {self.name}")
+        self.rsh_run(f"virsh pool-undefine {self.name}")


### PR DESCRIPTION
Commit c14c3c2bf8e3 ('Add capability to snapshot clusters (VMs only for
now)') dropped the pool handling, maybe because virt-install's "--disk"
argument changed from "pool=" to "path=".

However, even with "--disk path=", libvirt will still create a pool.
As installation progresses in parallel, two virt-install instances may
decide that they need to create the pool. This can result to a failure:
```
  2024-04-08 05:16:54 INFO: Finished starting VM nicmodecluster-master-3, cmd =
          virt-install
              --connect qemu:///system
              -n nicmodecluster-master-3
              -r 32768
              --cpu host
              --vcpus 8
              --os-variant=rhel8.6
              --import
              --network network=default,mac=52:54:cf:41:cb:f6
              --events on_reboot=restart
              --cdrom /home/nicmodecluster_guests_images/nicmodecluster-x86_64.iso
              --disk path=/home/nicmodecluster_guests_images/nicmodecluster-master-3.qcow2
              --wait=-1
          , ret = (returncode: 1, error: ERROR    Validating install media '/home/nicmodecluster_guests_images/nicmodecluster-x86_64.iso' failed: Could not define storage pool: operation failed: pool 'nicmodecluster_guests_images' alrea>
  )
```
This brings back cf2f4f6c1a7e ('Avoid initializing multiple times the
same pool') and partly revers commit  c14c3c2bf8e3 ('Add capability to
snapshot clusters (VMs only for now)').

Fixes: c14c3c2bf8e3 ('Add capability to snapshot clusters (VMs only for now)')
