### PR TITLE
[th/host-run-1]: change "env" argument for `Host.run()` and interpret commands as shell scripts

### DIFF
--- a/clusterNode.py
+++ b/clusterNode.py
@@ -1,6 +1,7 @@
 import abc
 import os
 import paramiko
+import shlex
 import sys
 import time
 from concurrent.futures import Future, ThreadPoolExecutor
@@ -144,6 +145,7 @@ class VmClusterNode(ClusterNode):
             --disk path={self.config.image_path}
             {append}
         """
+        cmd = shlex.join(shlex.split(cmd))
 
         logger.info(f"Starting VM {self.config.name}")
         ret = self.hostconn.run(cmd)

--- a/extraConfigDpuInfra.py
+++ b/extraConfigDpuInfra.py
@@ -118,9 +118,10 @@ def run_dpu_network_operator_git(lh: host.Host, kc: str) -> None:
     cur_dir = os.getcwd()
     os.chdir(repo_dir)
     lh.run("rm -rf bin")
-    env = os.environ.copy()
-    env["KUBECONFIG"] = kc
-    env["IMG"] = "quay.io/wizhao/dpu-network-operator:Nov1_WZ_DPU_DS_Test_1"
+    env = {
+        "KUBECONFIG": kc,
+        "IMG": "quay.io/wizhao/dpu-network-operator:Nov1_WZ_DPU_DS_Test_1",
+    }
     # cleanup first, to make this script idempotent
     logger.info("running make undeploy")
     logger.info(lh.run("make undeploy", env=env))

--- a/extraConfigSriov.py
+++ b/extraConfigSriov.py
@@ -28,8 +28,9 @@ def ExtraConfigSriov(cc: ClustersConfig, cfg: ExtraConfigArgs, futures: dict[str
 
     cur_dir = os.getcwd()
     os.chdir(repo_dir)
-    env = os.environ.copy()
-    env["KUBECONFIG"] = client._kc
+    env = {
+        "KUBECONFIG": client._kc,
+    }
 
     if cfg.image is not None:
         image = cfg.image
@@ -59,8 +60,9 @@ def ExtraConfigSriovSubscription(cc: ClustersConfig, cfg: ExtraConfigArgs, futur
     client = K8sClient(cc.kubeconfig)
     lh = host.LocalHost()
 
-    env = os.environ.copy()
-    env["KUBECONFIG"] = client._kc
+    env = {
+        "KUBECONFIG": client._kc,
+    }
 
     # cleanup first, to make this script idempotent
     logger.info("running make undeploy")

--- a/host.py
+++ b/host.py
@@ -328,8 +328,7 @@ class Host:
                     full_env.pop(k, None)
                 else:
                     full_env[k] = v
-        args = shlex.split(cmd)
-        res = subprocess.run(args, capture_output=True, env=full_env)
+        res = subprocess.run(cmd, shell=True, capture_output=True, env=full_env)
         return Result(
             res.stdout.decode("utf-8"),
             res.stderr.decode("utf-8"),

--- a/host.py
+++ b/host.py
@@ -378,9 +378,6 @@ class Host:
                     cmd2 += f"export {k}={shlex.quote(v)}\n"
             cmd = cmd2 + cmd
 
-        # Make sure multiline command is not seen as multiple commands
-        cmd = cmd.replace("\n", "\\\n")
-
         while True:
             try:
                 return read_output(cmd, log_level)

--- a/host.py
+++ b/host.py
@@ -329,19 +329,12 @@ class Host:
                 else:
                     full_env[k] = v
         args = shlex.split(cmd)
-        pipe = subprocess.PIPE
-        with subprocess.Popen(args, stdout=pipe, stderr=pipe, env=full_env) as proc:
-            if proc.stdout is None:
-                logger.info("Can't find stdout")
-                sys.exit(-1)
-            if proc.stderr is None:
-                logger.info("Can't find stderr")
-                sys.exit(-1)
-            out = proc.stdout.read().decode("utf-8")
-            err = proc.stderr.read().decode("utf-8")
-            proc.communicate()
-            ret = proc.returncode
-        return Result(out, err, ret)
+        res = subprocess.run(args, capture_output=True, env=full_env)
+        return Result(
+            res.stdout.decode("utf-8"),
+            res.stderr.decode("utf-8"),
+            res.returncode,
+        )
 
     def _run_remote(
         self,


### PR DESCRIPTION
This is a spin-off with the first patches from #133.