### PR TITLE
Add extra config to enable the image registry.

### DIFF
--- a/extraConfigImageRegistry.py
+++ b/extraConfigImageRegistry.py
@@ -1,0 +1,27 @@
+from clustersConfig import ClustersConfig
+from k8sClient import K8sClient
+from concurrent.futures import Future
+from typing import Optional
+from logger import logger
+from clustersConfig import ExtraConfigArgs
+import host
+
+
+def ExtraConfigImageRegistry(cc: ClustersConfig, cfg: ExtraConfigArgs, futures: dict[str, Future[Optional[host.Result]]]) -> None:
+    [f.result() for (_, f) in futures.items()]
+    logger.info("Running post config step to enable cluster registry")
+
+    # Reference documentation:
+    # https://docs.openshift.com/container-platform/4.15/registry/configuring-registry-operator.html
+
+    client = K8sClient(cc.kubeconfig)
+    client.oc_run_or_die("patch configs.imageregistry.operator.openshift.io cluster --type=merge --patch '{\"spec\":{\"managementState\":\"Managed\"}}'")
+    client.oc_run_or_die("patch configs.imageregistry.operator.openshift.io cluster --type=merge --patch '{\"spec\":{\"storage\":{\"emptyDir\":{},\"managementState\":\"Managed\"}}}'")
+
+
+def main() -> None:
+    pass
+
+
+if __name__ == "__main__":
+    main()

--- a/extraConfigRunner.py
+++ b/extraConfigRunner.py
@@ -4,6 +4,7 @@ from extraConfigDpuTenant import ExtraConfigDpuTenantMC, ExtraConfigDpuTenant, E
 from extraConfigDpuInfra import ExtraConfigDpuInfra, ExtraConfigDpuInfra_NewAPI
 from extraConfigOvnK import ExtraConfigOvnK
 from extraConfigCustomOvn import ExtraConfigCustomOvn
+from extraConfigImageRegistry import ExtraConfigImageRegistry
 from extraConfigCNO import ExtraConfigCNO
 from extraConfigRT import ExtraConfigRT
 from extraConfigDualStack import ExtraConfigDualStack
@@ -34,6 +35,7 @@ class ExtraConfigRunner:
             "dpu_tenant_new_api": ExtraConfigDpuTenant_NewAPI,
             "ovnk8s": ExtraConfigOvnK,
             "ovn_custom": ExtraConfigCustomOvn,
+            "image_registry": ExtraConfigImageRegistry,
             "cno": ExtraConfigCNO,
             "rt": ExtraConfigRT,
             "dualstack": ExtraConfigDualStack,


### PR DESCRIPTION
This is useful when running OpenShift builds, for example.