### PR TITLE
[th/log-once] improve the logging output by avoiding repeated messages and pretty-print elapsed time

### DIFF
--- a/arguments.py
+++ b/arguments.py
@@ -5,7 +5,7 @@ import sys
 import logging
 import argcomplete
 import difflib
-from logger import logger, configure_logger
+from logger import logger
 from typing import Optional
 
 VALID_STEPS = ["pre", "masters", "workers", "post"]
@@ -50,7 +50,7 @@ def remove_empty_strings(comma_string: str) -> list[str]:
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description='Cluster deployment automation')
     parser.add_argument('config', metavar='config', type=str, help='Yaml file with config').completer = yaml_completer  # type: ignore
-    parser.add_argument('-v', '--verbosity', choices=['debug', 'info', 'warning', 'error', 'critical'], default='info', help='Set the logging level (default: info)')
+    parser.add_argument('-v', '--verbosity', choices=['debug', 'info', 'warning', 'error', 'critical'], default='info', help='Set the logging level (default: info). All messages are written to "/tmp/cda*.log"')
     parser.add_argument('--secret', dest='secrets_path', default='', action='store', type=str, help='pull_secret.json path (default is in cwd)')
     parser.add_argument('--assisted-installer-url', dest='url', default='192.168.122.1', action='store', type=str, help='If set to 0.0.0.0 (the default), Assisted Installer will be started locally')
 
@@ -89,7 +89,7 @@ def parse_args() -> argparse.Namespace:
         args.worker_range = common.RangeList(args.workers)
         args.worker_range.exclude(args.skip_workers)
 
-    configure_logger(getattr(logging, args.verbosity.upper()))
+    logger.setLevel(getattr(logging, args.verbosity.upper()))
 
     if not args.secrets_path:
         args.secrets_path = os.path.join(os.getcwd(), "pull_secret.json")

--- a/clusterDeployer.py
+++ b/clusterDeployer.py
@@ -571,13 +571,15 @@ class ClusterDeployer:
         lh = host.LocalHost()
         bf_workers = [x for x in self._cc.workers if x.kind == "bf"]
         connections: dict[str, host.Host] = {}
+        logger.info_once_reset()
         for try_count in itertools.count(0):
             workers = [w.name for w in self._cc.workers]
             n_not_ready_workers = sum(1 for w in workers if not self.client().is_ready(w))
             if n_not_ready_workers == 0:
                 break
 
-            logger.info(f"Not all workers ready (try #{try_count}). {n_not_ready_workers} are not ready yet.")
+            logger.info_once(f"Not all workers ready. {n_not_ready_workers} are not ready yet.")
+
             self.client().approve_csr()
 
             if len(connections) != len(bf_workers):

--- a/common.py
+++ b/common.py
@@ -215,6 +215,51 @@ def iterate_ssh_keys() -> Iterator[tuple[str, str, str]]:
             yield pub_file, pub_key_content, priv_key_file
 
 
+def seconds_to_str(seconds: float) -> str:
+    sign = ""
+    if seconds == 0.0:
+        return "0s"
+    if seconds < 0:
+        seconds = -seconds
+        sign = "-"
+
+    seconds = round(seconds, 3)
+
+    if seconds == 0.0:
+        # This would have been rounded to zero. But it's not really zero.
+        # Break our usual rounding, and return the close to the next non-zero
+        # value.
+        return f"{sign}0.001s"
+
+    i_sec_total = int(seconds)
+    i_min, i_sec = divmod(i_sec_total, 60)
+    i_hour, i_min = divmod(i_min, 60)
+    i_days, i_hour = divmod(i_hour, 24)
+
+    f_sec = i_sec + (seconds - i_sec_total)
+
+    sep = ""
+
+    res = sign
+    if i_days > 0:
+        res += f"{sep}{i_days}d"
+        sep = " "
+    if i_hour > 0 or (sep and (i_min > 0 or f_sec > 0.0)):
+        res += f"{sep}{i_hour}h"
+        sep = " "
+    if i_min > 0 or (sep and (f_sec > 0.0)):
+        res += f"{sep}{i_min}m"
+        sep = " "
+    if f_sec > 0.0:
+        if f_sec == int(f_sec):
+            res += f"{sep}{int(f_sec)}s"
+        else:
+            x = f"{f_sec:.3f}".rstrip("0")
+            res += f"{sep}{x}s"
+
+    return res
+
+
 def kubeconfig_get_paths(cluster_name: str, kubeconfig_path: Optional[str]) -> tuple[str, str, str, str]:
     # AssistedClient.download_kubeconfig() downloads the kubeconfig at a
     # particular place, determined by the @cluster_name and @kubeconfig_path.

--- a/k8sClient.py
+++ b/k8sClient.py
@@ -1,3 +1,4 @@
+import common
 import kubernetes
 import yaml
 import time
@@ -69,7 +70,7 @@ class K8sClient:
         time.sleep(60)
         iteration = 0
         max_tries = 10
-        start = time.time()
+        start = time.monotonic()
         while True:
             ret = self.oc(f"wait mcp {mcp_name} --for condition=updated --timeout=20m")
             if ret.returncode == 0:
@@ -80,5 +81,4 @@ class K8sClient:
                 sys.exit(-1)
             iteration = iteration + 1
             time.sleep(60)
-        minutes, seconds = divmod(int(time.time() - start), 60)
-        logger.info(f"It took {minutes}m {seconds}s for {resource} (attempts: {iteration})")
+        logger.info(f"It took {common.seconds_to_str(time.monotonic() - start)} for {resource} (attempts: {iteration})")

--- a/logger.py
+++ b/logger.py
@@ -1,58 +1,78 @@
+import datetime
 import logging
 import os
 import sys
 import typing
 from typing import Optional
-from typing import TextIO
+
+
+_eval_level_global: Optional[int] = None
+
+
+def _eval_level(level: Optional[int | str]) -> int:
+    if level is not None:
+        if isinstance(level, str):
+            return typing.cast(int, getattr(logging, level.strip().upper()))
+        return level
+
+    global _eval_level_global
+    if _eval_level_global is not None:
+        return _eval_level_global
+
+    level = logging.INFO
+    s = os.environ.get("CDA_LOG_LEVEL")
+    if s:
+        s = s.strip().upper()
+        if s in ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"):
+            level = typing.cast(int, getattr(logging, s))
+    _eval_level_global = level
+    return level
 
 
 class ExtendedLogger(logging.Logger):
-    def __init__(self, logger: logging.Logger):
-        self._wrapped_logger = logger
+    def __init__(self, name: str) -> None:
 
-    def __getattribute__(self: 'ExtendedLogger', name: str) -> typing.Any:
-        # ExtendedLogger is-a logging.Logger, but it delegates most calls to
-        # the wrapped-logger (which is also a logging.Logger).
-        if name == 'error_and_exit':
-            return object.__getattribute__(self, name)
-        logger = object.__getattribute__(self, '_wrapped_logger')
-        return logger.__getattribute__(name)
+        fmt = "%(asctime)s %(levelname)s: %(message)s"
+        datefmt = "%Y-%m-%d %H:%M:%S"
+        formatter = logging.Formatter(fmt, datefmt)
+
+        main_handler = logging.StreamHandler()
+        main_handler.setLevel(_eval_level(None))
+        main_handler.setFormatter(formatter)
+
+        self._formatter = formatter
+        self._main_handler = main_handler
+        self._file_handler: Optional[logging.FileHandler] = None
+
+        super().__init__(name, level=logging.NOTSET + 1)
+        self.addHandler(main_handler)
+
+    def setLevel(self, level: Optional[int | str] = None) -> None:
+        level = _eval_level(level)
+        self._main_handler.setLevel(level)
+
+        if self._file_handler is None:
+            # We only setup the file handler during setLevel. Unit tests
+            # generally don't call this, so we don't write the logs to file.
+            timestamp = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
+            file_handler = logging.FileHandler(f"/tmp/cda-{timestamp}-{os.getpid()}.log")
+            file_handler.setFormatter(self._formatter)
+            self._file_handler = file_handler
+            self.addHandler(file_handler)
 
     def error_and_exit(self: 'ExtendedLogger', msg: str, *, exit_code: int = -1) -> typing.NoReturn:
         self.error(msg)
         sys.exit(exit_code)
 
 
-def configure_logger(lvl: Optional[int] = None) -> ExtendedLogger:
-    logger = logging.getLogger("CDA")
-
-    if lvl is None:
-        lvl = logging.INFO
-        s = os.environ.get("CDA_LOG_LEVEL")
-        if s:
-            s = s.strip().upper()
-            if s in ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"):
-                lvl = typing.cast(int, getattr(logging, s))
-
-    logger.setLevel(lvl)
-
-    fmt = "%(asctime)s %(levelname)s: %(message)s"
-    datefmt = "%Y-%m-%d %H:%M:%S"
-    formatter = logging.Formatter(fmt, datefmt)
-
-    handler = logging.StreamHandler()
-    handler.setLevel(lvl)
-    handler.setFormatter(formatter)
-
-    global prev_handler
-    if prev_handler is not None:
-        logger.removeHandler(prev_handler)
-    prev_handler = handler
-    logger.addHandler(handler)
-
-    return ExtendedLogger(logger)
-
-
-prev_handler: Optional['logging.StreamHandler[TextIO]'] = None
-
-logger = configure_logger()
+# We want that our logger is of type ExtendedLogger to make typing happy. But
+# we don't want that other instances of logging.getLogger() are.
+#
+# The way by overwriting the logger class here brings some limitation:
+# - you MUST NOT call logging.getLogger("CDA") *before* importing this module.
+# - you MUST NOT have another thread calling logging.getLogger() while importing
+#   this module.
+logging.Logger.manager.setLoggerClass(ExtendedLogger)
+logger = typing.cast(ExtendedLogger, logging.getLogger("CDA"))
+logging.Logger.manager.setLoggerClass(logging.Logger)
+assert isinstance(logger, ExtendedLogger)

--- a/test_common.py
+++ b/test_common.py
@@ -10,6 +10,62 @@ def _read_file(filename: str) -> str:
         return f.read()
 
 
+def test_seconds_to_str() -> None:
+    def _t(val: float, *, negative_test: bool = False) -> str:
+        if negative_test:
+            assert val < 0.0
+        else:
+            assert val >= 0.0
+        res = common.seconds_to_str(float(val))
+        if val == int(val):
+            assert res == common.seconds_to_str(int(val))
+
+        if val > 0.0:
+            assert f"-{res}" == _t(float(-val), negative_test=True)
+
+        return res
+
+    def _t2(d: int, h: int, m: int, s: float) -> str:
+        return _t((((((d * 24) + h) * 60) + m) * 60) + s)
+
+    assert _t(0) == "0s"
+    assert _t(0.4) == "0.4s"
+
+    assert _t(0.000001) == "0.001s"
+
+    assert _t(0) == "0s"
+    assert _t(0.9994) == "0.999s"
+    assert _t(0.9996) == "1s"
+    assert _t(0.999999) == "1s"
+    assert _t(1) == "1s"
+
+    assert _t(59) == "59s"
+    assert _t(59.9994) == "59.999s"
+    assert _t(59.9996) == "1m"
+    assert _t(59.999999) == "1m"
+    assert _t(60) == "1m"
+
+    assert _t2(0, 0, 5, 0) == "5m"
+    assert _t2(0, 0, 5, 1) == "5m 1s"
+    assert _t2(0, 0, 5, 1.1) == "5m 1.1s"
+
+    assert _t2(4, 0, 0, 0) == "4d"
+    assert _t2(4, 21, 0, 0) == "4d 21h"
+    assert _t2(4, 0, 3, 0) == "4d 0h 3m"
+    assert _t2(4, 0, 3, 44) == "4d 0h 3m 44s"
+    assert _t2(4, 18, 55, 0.43) == "4d 18h 55m 0.43s"
+
+    assert _t2(4, 23, 59, 59.9994) == "4d 23h 59m 59.999s"
+    assert _t2(4, 23, 59, 59.9996) == "5d"
+
+    assert _t2(5, 0, 0, 0) == "5d"
+    assert _t2(5, 0, 0, 0.1) == "5d 0h 0m 0.1s"
+    assert _t2(5, 0, 59, 59.9994) == "5d 0h 59m 59.999s"
+    assert _t2(5, 0, 59, 59.9996) == "5d 1h"
+
+    assert _t2(50000000000, 0, 59, 59.9996) == "50000000000d 1h"
+
+
 def test_atomic_write(tmp_path: pathlib.Path) -> None:
 
     user = os.geteuid()


### PR DESCRIPTION
- avoid logging repeated messages about waiting. It spams the terminal. Only log the first distinct message at INFO level, later messages as DEBUG level.
- add `common.seconds_to_str()` helper to pretty-print elapsed time (in seconds) and use it. The point is to make the log easier to read.