### PR TITLE
[th/ai-find-pod-return] assistedInstallerService: annotate return type of find_pod()

### DIFF
--- a/assistedInstallerService.py
+++ b/assistedInstallerService.py
@@ -7,7 +7,6 @@ import re
 import filecmp
 from typing import Optional
 from typing import Union
-from typing import Any
 from typing import Sequence
 import yaml
 import requests
@@ -228,7 +227,7 @@ class AssistedInstallerService:
     def get_normal_pullspec(self, version: str) -> str:
         return f"quay.io/openshift-release-dev/ocp-release:{version}-multi"
 
-    def find_pod(self, name: str) -> Optional[Any]:
+    def find_pod(self, name: str) -> Optional[dict[str, str]]:
         lh = host.LocalHost()
         result = lh.run("podman pod ps --format json")
         if result.err:


### PR DESCRIPTION
It's not clear what the return type really is. We just parse a JSON we receive without validating the content.

Maybe some validation should be done.

Regardless, the closest type of what we return here is a strdict. Annotate the return type.