### PR TITLE
clustersConfig: Change default IP range to 192.168.122.1-192.168.122.254.

### DIFF
--- a/arguments.py
+++ b/arguments.py
@@ -52,7 +52,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument('config', metavar='config', type=str, help='Yaml file with config').completer = yaml_completer  # type: ignore
     parser.add_argument('-v', '--verbosity', choices=['debug', 'info', 'warning', 'error', 'critical'], default='info', help='Set the logging level (default: info)')
     parser.add_argument('--secret', dest='secrets_path', default='', action='store', type=str, help='pull_secret.json path (default is in cwd)')
-    parser.add_argument('--assisted-installer-url', dest='url', default='192.168.1.1', action='store', type=str, help='If set to 0.0.0.0 (the default), Assisted Installer will be started locally')
+    parser.add_argument('--assisted-installer-url', dest='url', default='192.168.122.1', action='store', type=str, help='If set to 0.0.0.0 (the default), Assisted Installer will be started locally')
 
     subparsers = parser.add_subparsers(title='subcommands', dest='subcommand')
     deploy_parser = subparsers.add_parser('deploy', help='Deploy clusters')

--- a/clustersConfig.py
+++ b/clustersConfig.py
@@ -182,7 +182,7 @@ class ClustersConfig:
         if "base_dns_domain" in cc:
             self.base_dns_domain = cc["base_dns_domain"]
         if "ip_range" not in cc:
-            cc["ip_range"] = "192.168.1.1-192.168.255.254"
+            cc["ip_range"] = "192.168.122.1-192.168.122.254"
         if "ip_mask" not in cc:
             cc["ip_mask"] = "255.255.0.0"
 


### PR DESCRIPTION
Partially revert 54b9fb9df004 ("clustersConfig: Set default IP subnet to 192.168.0.0/16.").  The part that ensures that the virbr configuration is valid is OK to keep.