### PR TITLE
Fix removing DHCP entries.

### DIFF
--- a/clusterDeployer.py
+++ b/clusterDeployer.py
@@ -119,8 +119,12 @@ class ClusterDeployer:
         removed_macs = []
         names = [x.name for x in self._cc.all_vms()]
         ips = [x.ip for x in self._cc.all_vms()]
-        for e in q[-1][0][1:]:
-            if e.attrib["name"] in names or e.attrib["ip"] in ips:
+        dhcp = None
+        ip_tree = q.find('ip')
+        if ip_tree:
+            dhcp = ip_tree.find('dhcp')
+        for e in dhcp or []:
+            if e.get('name') in names or e.get('ip') in ips:
                 mac = e.attrib["mac"]
                 name = e.attrib["name"]
                 ip = e.attrib["ip"]


### PR DESCRIPTION
Avoid using cryptic q[-1][0](1:] which is sensitive to bridge configuration changes. Following commit changed the bridge configuration and hence q[-1] stopped pointing to ip.

Fixes: 03f05ec595ee ('dns: ensure libvirt's dnsmasq does not forward to the local dnsmasq')