### PR TITLE
Fix nightly pullspecs

### DIFF
--- a/assistedInstallerService.py
+++ b/assistedInstallerService.py
@@ -178,28 +178,22 @@ class AssistedInstallerService:
                 'version': version,
             }
         elif re.search(r'4\.14\.0-ec.[0-9]+', version):
-            # workaround: if openshift_version == 4.14-multi, and
-            # version == "4.14.0" nightly, it errors out. Instead
-            # pretend that we are installing 4.13, but use the 4.14
-            # pullspec
-            wa_version = version.replace("4.14", "4.13")
             ret = {
-                'openshift_version': '4.13-multi',
+                'openshift_version': '4.14-multi',
                 'cpu_architectures': ['x86_64', 'arm64', 'ppc64le', 's390x'],
                 'url': self.get_normal_pullspec(version),
-                'version': wa_version,
+                'version': version,
             }
         elif re.search(r'4\.14\.0-nightly', version):
-            wa_version = "4.13.0-nighty"
             ret = {
-                'openshift_version': '4.13-multi',
+                'openshift_version': '4.14-multi',
                 'cpu_architectures': ['x86_64', 'arm64', 'ppc64le', 's390x'],
                 'url': self.get_nightly_pullspec(version),
-                'version': wa_version,
+                'version': version,
             }
         elif re.search(r'4\.14\.[0-9]+', version):
             ret = {
-                'openshift_version': '4.13-multi',
+                'openshift_version': '4.14-multi',
                 'cpu_architectures': ['x86_64', 'arm64', 'ppc64le', 's390x'],
                 'url': self.get_normal_pullspec(version),
                 'version': version,
@@ -212,12 +206,11 @@ class AssistedInstallerService:
                 'version': version,
             }
         elif re.search(r'4\.15\.0-nightly', version):
-            wa_version = "4.15.0-nighty"
             ret = {
                 'openshift_version': '4.15-multi',
                 'cpu_architectures': ['x86_64', 'arm64', 'ppc64le', 's390x'],
                 'url': self.get_nightly_pullspec(version),
-                'version': wa_version,
+                'version': version,
             }
         elif re.search(r'4\.15\.[0-9]+', version):
             ret = {
@@ -234,12 +227,11 @@ class AssistedInstallerService:
                 'version': version,
             }
         elif re.search(r'4\.16\.0-nightly', version):
-            wa_version = "4.16.0-nighty"
             ret = {
                 'openshift_version': '4.16-multi',
                 'cpu_architectures': ['x86_64', 'arm64', 'ppc64le', 's390x'],
                 'url': self.get_nightly_pullspec(version),
-                'version': wa_version,
+                'version': version,
             }
         elif re.search(r'4\.16\.[0-9]+', version):
             ret = {

--- a/assistedInstallerService.py
+++ b/assistedInstallerService.py
@@ -132,21 +132,21 @@ class AssistedInstallerService:
         return y
 
     def prep_version(self, version: str) -> dict[str, Union[str, Sequence[str]]]:
-        if re.search(r'4\.12\.[0-9]+', version):
+        if re.search(r'4\.12\.0-nightly', version):
             # Note how 4.12.0 has the -multi suffix because AI requires that
             # for 4.12. CDA hides this and simply expect 4.12.0 from the user
             # since that follows the same versioning scheme
             ret = {
-                'openshift_version': f'{version}',
-                'cpu_architectures': ['x86_64', 'arm64', 'ppc64le', 's390x'],
-                'url': self.get_normal_pullspec(version.rstrip("-multi")),
-                'version': version,
-            }
-        elif re.search(r'4\.12\.0-nightly', version):
-            ret = {
                 'openshift_version': '4.12-multi',
                 'cpu_architectures': ['x86_64', 'arm64', 'ppc64le', 's390x'],
                 'url': self.get_nightly_pullspec(version),
+                'version': version,
+            }
+        elif re.search(r'4\.12\.[0-9]+', version):
+            ret = {
+                'openshift_version': f'{version}',
+                'cpu_architectures': ['x86_64', 'arm64', 'ppc64le', 's390x'],
+                'url': self.get_normal_pullspec(version.rstrip("-multi")),
                 'version': version,
             }
         elif re.search(r'4\.13\.0-ec.[0-9]+', version):

--- a/assistedInstallerService.py
+++ b/assistedInstallerService.py
@@ -132,10 +132,17 @@ class AssistedInstallerService:
         return y
 
     def prep_version(self, version: str) -> dict[str, Union[str, Sequence[str]]]:
-        if re.search(r'4\.12\.0-nightly', version):
-            # Note how 4.12.0 has the -multi suffix because AI requires that
-            # for 4.12. CDA hides this and simply expect 4.12.0 from the user
-            # since that follows the same versioning scheme
+        # Note how 4.12.0 has the -multi suffix because AI requires that
+        # for 4.12. CDA hides this and simply expect 4.12.0 from the user
+        # since that follows the same versioning scheme
+        if re.search(r'4\.12\.0-ec.[0-9]+', version):
+            ret = {
+                'openshift_version': '4.12-multi',
+                'cpu_architectures': ['x86_64', 'arm64', 'ppc64le', 's390x'],
+                'url': self.get_normal_pullspec(version),
+                'version': version,
+            }
+        elif re.search(r'4\.12\.0-nightly', version):
             ret = {
                 'openshift_version': '4.12-multi',
                 'cpu_architectures': ['x86_64', 'arm64', 'ppc64le', 's390x'],
@@ -184,30 +191,62 @@ class AssistedInstallerService:
             }
         elif re.search(r'4\.14\.0-nightly', version):
             wa_version = "4.13.0-nighty"
-
             ret = {
                 'openshift_version': '4.13-multi',
                 'cpu_architectures': ['x86_64', 'arm64', 'ppc64le', 's390x'],
                 'url': self.get_nightly_pullspec(version),
                 'version': wa_version,
             }
+        elif re.search(r'4\.14\.[0-9]+', version):
+            ret = {
+                'openshift_version': '4.13-multi',
+                'cpu_architectures': ['x86_64', 'arm64', 'ppc64le', 's390x'],
+                'url': self.get_normal_pullspec(version),
+                'version': version,
+            }
+        elif re.search(r'4\.15\.0-ec.[0-9]+', version):
+            ret = {
+                'openshift_version': '4.15-multi',
+                'cpu_architectures': ['x86_64', 'arm64', 'ppc64le', 's390x'],
+                'url': self.get_normal_pullspec(version),
+                'version': version,
+            }
         elif re.search(r'4\.15\.0-nightly', version):
             wa_version = "4.15.0-nighty"
-
             ret = {
                 'openshift_version': '4.15-multi',
                 'cpu_architectures': ['x86_64', 'arm64', 'ppc64le', 's390x'],
                 'url': self.get_nightly_pullspec(version),
                 'version': wa_version,
             }
+        elif re.search(r'4\.15\.[0-9]+', version):
+            ret = {
+                'openshift_version': '4.15-multi',
+                'cpu_architectures': ['x86_64', 'arm64', 'ppc64le', 's390x'],
+                'url': self.get_normal_pullspec(version),
+                'version': version,
+            }
+        elif re.search(r'4\.16\.0-ec.[0-9]+', version):
+            ret = {
+                'openshift_version': '4.16-multi',
+                'cpu_architectures': ['x86_64', 'arm64', 'ppc64le', 's390x'],
+                'url': self.get_normal_pullspec(version),
+                'version': version,
+            }
         elif re.search(r'4\.16\.0-nightly', version):
             wa_version = "4.16.0-nighty"
-
             ret = {
                 'openshift_version': '4.16-multi',
                 'cpu_architectures': ['x86_64', 'arm64', 'ppc64le', 's390x'],
                 'url': self.get_nightly_pullspec(version),
                 'version': wa_version,
+            }
+        elif re.search(r'4\.16\.[0-9]+', version):
+            ret = {
+                'openshift_version': '4.16-multi',
+                'cpu_architectures': ['x86_64', 'arm64', 'ppc64le', 's390x'],
+                'url': self.get_normal_pullspec(version),
+                'version': version,
             }
         else:
             logger.error(f"Unknown version {version}")

--- a/cda.py
+++ b/cda.py
@@ -24,13 +24,6 @@ def main_deploy(args: argparse.Namespace) -> None:
     if args.url == cc.ip_range[0] and not cc.kind == "microshift":
         ais = AssistedInstallerService(cc.version, args.url, cc.proxy, cc.noproxy)
         ais.start()
-        # workaround, this will still install 4.14, but AI will think
-        # it is 4.13 (see also workaround when setting up versions)
-        if cc.version[: len("4.14")] == "4.14":
-            logger.warning("Applying workaround for assisted installer issue")
-            logger.warning("Will pretend to install 4.13, but using 4.14 pullsec")
-            logger.warning("Ignore all output from Assisted that mentions 4.13")
-            cc.version = "4.13.0-nightly"
     else:
         logger.info(f"Will use Assisted Installer running at {args.url}")
         ais = None


### PR DESCRIPTION
Previously, we would false match on r'4\.12\.[0-9]+' when trying to deploy 4.12.0-nightly, resulting in a bad pullspec. First try to match on the more specific nightly / ec regex.

Add consistency in version checking scheme and remove unnecessary workaround for 4.14 installation.