### PR TITLE
Fix and log the bridge reconfiguration events.

### DIFF
--- a/virtualBridge.py
+++ b/virtualBridge.py
@@ -159,20 +159,25 @@ class VirBridge:
 
         expected_dhcp_range = bridge_dhcp_range_str(self.config.dynamic_ip_range)
         if expected_dhcp_range not in ret.out:
+            logger.info("Bridge needs to be reconfigured: missing expected dhcp range")
             needs_reconfigure = True
 
         if not expected_dhcp_range and "dhcp" in ret.out:
+            logger.info("Bridge needs to be reconfigured: unexpected dhcp range present")
             needs_reconfigure = True
 
         # Make sure STP is off on the virtual bridge.
         if "stp='off'" not in ret.out:
+            logger.info("Bridge needs to be reconfigured: stp enabled")
             needs_reconfigure = True
 
         # Make sure the correct bridge IP is configured.
         if bridge_ip_address_str(self.config.ip, self.config.mask) not in ret.out:
+            logger.info("Bridge needs to be reconfigured: unexpected bridge IP")
             needs_reconfigure = True
 
         if use_resolvconf_orig != (f"resolv-file={dnsutil.RESOLVCONF_ORIG}" in ret.out):
+            logger.info("Bridge needs to be reconfigured: missing resolv-file")
             needs_reconfigure = True
 
         if needs_reconfigure:

--- a/virtualBridge.py
+++ b/virtualBridge.py
@@ -172,7 +172,7 @@ class VirBridge:
         if bridge_ip_address_str(self.config.ip, self.config.mask) not in ret.out:
             needs_reconfigure = True
 
-        if use_resolvconf_orig != (f"\"resolv-file={dnsutil.RESOLVCONF_ORIG}\"" in ret.out):
+        if use_resolvconf_orig != (f"resolv-file={dnsutil.RESOLVCONF_ORIG}" in ret.out):
             needs_reconfigure = True
 
         if needs_reconfigure:


### PR DESCRIPTION
There's no guarantee that "virsh net-define <file>" doesn't replace
double quotes with single quotes.  For example, on RHEL 9.3:

  $ virsh --version
  9.5.0

  $  cat /tmp/vir_bridge.xml | grep resolv-file
     <dnsmasq:options><dnsmasq:option value="resolv-file=/etc/resolv.conf.cda-orig" /></dnsmasq:options>

  $ virsh net-define /tmp/vir_bridge.xml
  Network default defined from /tmp/vir_bridge.xml

  $ virsh net-dumpxml default | grep resolv-file
    <dnsmasq:option value='resolv-file=/etc/resolv.conf.cda-orig'/>

The second commit in this PR logs the reasons why the bridge had to be reconfigured.