### PR TITLE
avoid Prometheus killing cluster

### DIFF
--- a/clusterDeployer.py
+++ b/clusterDeployer.py
@@ -227,6 +227,8 @@ class ClusterDeployer:
 
         if "post" in self.steps:
             self._postconfig()
+            cmd = "apply -f monitoring-config.yaml"
+            self.client().oc_run_or_die(cmd)
         else:
             logger.info("Skipping post configuration.")
 

--- a/monitoring-config.yaml
+++ b/monitoring-config.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    prometheusK8s:
+      retention: "72h"
+


### PR DESCRIPTION
Prometheus uses lots of disk space, until all space is used, which causes master nodes to start to fail and cluster to become unresponsive.