### PR TITLE
[th/log-debug-to-file] logger: log all debug messages to file

### DIFF
--- a/arguments.py
+++ b/arguments.py
@@ -5,7 +5,7 @@ import sys
 import logging
 import argcomplete
 import difflib
-from logger import logger, configure_logger
+from logger import logger
 from typing import Optional
 
 VALID_STEPS = ["pre", "masters", "workers", "post"]
@@ -50,7 +50,7 @@ def remove_empty_strings(comma_string: str) -> list[str]:
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description='Cluster deployment automation')
     parser.add_argument('config', metavar='config', type=str, help='Yaml file with config').completer = yaml_completer  # type: ignore
-    parser.add_argument('-v', '--verbosity', choices=['debug', 'info', 'warning', 'error', 'critical'], default='info', help='Set the logging level (default: info)')
+    parser.add_argument('-v', '--verbosity', choices=['debug', 'info', 'warning', 'error', 'critical'], default='info', help='Set the logging level (default: info). All messages are written to "/tmp/cda*.log"')
     parser.add_argument('--secret', dest='secrets_path', default='', action='store', type=str, help='pull_secret.json path (default is in cwd)')
     parser.add_argument('--assisted-installer-url', dest='url', default='192.168.122.1', action='store', type=str, help='If set to 0.0.0.0 (the default), Assisted Installer will be started locally')
 
@@ -89,7 +89,7 @@ def parse_args() -> argparse.Namespace:
         args.worker_range = common.RangeList(args.workers)
         args.worker_range.exclude(args.skip_workers)
 
-    configure_logger(getattr(logging, args.verbosity.upper()))
+    logger.setLevel(getattr(logging, args.verbosity.upper()))
 
     if not args.secrets_path:
         args.secrets_path = os.path.join(os.getcwd(), "pull_secret.json")

--- a/logger.py
+++ b/logger.py
@@ -1,58 +1,78 @@
+import datetime
 import logging
 import os
 import sys
 import typing
 from typing import Optional
-from typing import TextIO
+
+
+_eval_level_global: Optional[int] = None
+
+
+def _eval_level(level: Optional[int | str]) -> int:
+    if level is not None:
+        if isinstance(level, str):
+            return typing.cast(int, getattr(logging, level.strip().upper()))
+        return level
+
+    global _eval_level_global
+    if _eval_level_global is not None:
+        return _eval_level_global
+
+    level = logging.INFO
+    s = os.environ.get("CDA_LOG_LEVEL")
+    if s:
+        s = s.strip().upper()
+        if s in ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"):
+            level = typing.cast(int, getattr(logging, s))
+    _eval_level_global = level
+    return level
 
 
 class ExtendedLogger(logging.Logger):
-    def __init__(self, logger: logging.Logger):
-        self._wrapped_logger = logger
+    def __init__(self, name: str) -> None:
 
-    def __getattribute__(self: 'ExtendedLogger', name: str) -> typing.Any:
-        # ExtendedLogger is-a logging.Logger, but it delegates most calls to
-        # the wrapped-logger (which is also a logging.Logger).
-        if name == 'error_and_exit':
-            return object.__getattribute__(self, name)
-        logger = object.__getattribute__(self, '_wrapped_logger')
-        return logger.__getattribute__(name)
+        fmt = "%(asctime)s %(levelname)s: %(message)s"
+        datefmt = "%Y-%m-%d %H:%M:%S"
+        formatter = logging.Formatter(fmt, datefmt)
+
+        main_handler = logging.StreamHandler()
+        main_handler.setLevel(_eval_level(None))
+        main_handler.setFormatter(formatter)
+
+        self._formatter = formatter
+        self._main_handler = main_handler
+        self._file_handler: Optional[logging.FileHandler] = None
+
+        super().__init__(name, level=logging.NOTSET + 1)
+        self.addHandler(main_handler)
+
+    def setLevel(self, level: Optional[int | str] = None) -> None:
+        level = _eval_level(level)
+        self._main_handler.setLevel(level)
+
+        if self._file_handler is None:
+            # We only setup the file handler during setLevel. Unit tests
+            # generally don't call this, so we don't write the logs to file.
+            timestamp = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
+            file_handler = logging.FileHandler(f"/tmp/cda-{timestamp}-{os.getpid()}.log")
+            file_handler.setFormatter(self._formatter)
+            self._file_handler = file_handler
+            self.addHandler(file_handler)
 
     def error_and_exit(self: 'ExtendedLogger', msg: str, *, exit_code: int = -1) -> typing.NoReturn:
         self.error(msg)
         sys.exit(exit_code)
 
 
-def configure_logger(lvl: Optional[int] = None) -> ExtendedLogger:
-    logger = logging.getLogger("CDA")
-
-    if lvl is None:
-        lvl = logging.INFO
-        s = os.environ.get("CDA_LOG_LEVEL")
-        if s:
-            s = s.strip().upper()
-            if s in ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"):
-                lvl = typing.cast(int, getattr(logging, s))
-
-    logger.setLevel(lvl)
-
-    fmt = "%(asctime)s %(levelname)s: %(message)s"
-    datefmt = "%Y-%m-%d %H:%M:%S"
-    formatter = logging.Formatter(fmt, datefmt)
-
-    handler = logging.StreamHandler()
-    handler.setLevel(lvl)
-    handler.setFormatter(formatter)
-
-    global prev_handler
-    if prev_handler is not None:
-        logger.removeHandler(prev_handler)
-    prev_handler = handler
-    logger.addHandler(handler)
-
-    return ExtendedLogger(logger)
-
-
-prev_handler: Optional['logging.StreamHandler[TextIO]'] = None
-
-logger = configure_logger()
+# We want that our logger is of type ExtendedLogger to make typing happy. But
+# we don't want that other instances of logging.getLogger() are.
+#
+# The way by overwriting the logger class here brings some limitation:
+# - you MUST NOT call logging.getLogger("CDA") *before* importing this module.
+# - you MUST NOT have another thread calling logging.getLogger() while importing
+#   this module.
+logging.Logger.manager.setLoggerClass(ExtendedLogger)
+logger = typing.cast(ExtendedLogger, logging.getLogger("CDA"))
+logging.Logger.manager.setLoggerClass(logging.Logger)
+assert isinstance(logger, ExtendedLogger)


### PR DESCRIPTION
For regular run, the debug output is too verbose. It overwhelms the user with information, that is usually not used.

Unless, you want to debug a problem. If you then didn't have debug logging enable from the start, you would wish to still have those messages somewhere.

Solve that by always writing all messages to "/tmp/cda-*.log".