### PR TITLE
[th/dnsmasq-servers-file] dns: fix dnsmasq "server" option to only lookup apps.cluster.redhat.com

### DIFF
--- a/test_dnsutil.py
+++ b/test_dnsutil.py
@@ -1,5 +1,7 @@
 import pathlib
 
+from typing import Optional
+
 import dnsutil
 
 
@@ -10,7 +12,7 @@ def test_resolv_conf_parse_file(tmp_path: pathlib.Path) -> None:
             content = content.encode('utf-8')
         with open(filename, "wb") as f:
             f.write(content)
-        rcdata = dnsutil.resolvconf_parse_file(filename)
+        rcdata = dnsutil._resolvconf_parse_file(filename)
         return (rcdata.nameservers, rcdata.searches)
 
     assert _rc("nameserver  1.2.3.4") == (["1.2.3.4"], [])
@@ -23,3 +25,66 @@ def test_resolv_conf_parse_file(tmp_path: pathlib.Path) -> None:
     assert _rc(b"nameserver\t1::0\xca4\nnameserver 1.2.3.4  ") == (["1.2.3.4"], [])
     assert _rc("search foo.com bar.com\nnameserver  1.2.3.4\n") == (["1.2.3.4"], ["foo.com", "bar.com"])
     assert _rc("search foo.com bar.com\n\nsearch xxx\nnameserver  1.2.3.4\n") == (["1.2.3.4"], ["xxx"])
+
+
+def test_dnsmasq_servers_parse() -> None:
+    def _update(old_content: bytes, cluster_name: Optional[str], api_vip: Optional[str] = None) -> tuple[bytes, list[bytes]]:
+        content, entries = dnsutil._dnsmasq_servers_content_update(old_content, cluster_name, api_vip)
+        assert content
+        assert isinstance(content, bytes)
+        assert isinstance(entries, list)
+
+        # Reimplement the parsing, and see that we get the same result
+        found_entries = []
+        for line in content.split(b'\n'):
+            assert line == line.strip()
+            if not line:
+                continue
+            if line.startswith(b'#'):
+                assert line == b"#" or line.startswith(b"# ")
+                continue
+            assert line.startswith(b"server=/")
+            found_entries.append(line)
+        assert entries == found_entries
+
+        # parsing the content again, should yield the same entries.
+        entries2 = dnsutil._dnsmasq_servers_content_parse(content)
+        assert isinstance(entries, list)
+        assert entries == entries2
+
+        # Calling update on the new content, must give the identical output.
+        content3, entries3 = dnsutil._dnsmasq_servers_content_update(content, cluster_name, api_vip)
+        assert content3
+        assert isinstance(content3, bytes)
+        assert isinstance(entries3, list)
+        assert content3 == content
+        assert entries3 == entries
+
+        return content, entries
+
+    content, entries = _update(b"", "cluster1", "192.168.122.2")
+    assert content == (
+        b'# Written by cluster-deployment-automation for resolving cluster names.\n'
+        b'# This file is passed to dnsmasq via the --servers-file= option\n'
+        b'#\n'
+        b'# You can reload after changes with\n'
+        b'#   systemctl restart dnsmasq.service\n'
+        b'#   systemctl kill -s SIGHUP dnsmasq.service\n'
+        b'server=/*.api.cluster1.redhat.com/*.api-int.cluster1.redhat.com/#\n'
+        b'server=/apps.cluster1.redhat.com/api.cluster1.redhat.com/api-int.cluster1.redhat.com/192.168.122.2\n'
+    )
+    assert entries == [
+        b'server=/*.api.cluster1.redhat.com/*.api-int.cluster1.redhat.com/#',
+        b'server=/apps.cluster1.redhat.com/api.cluster1.redhat.com/api-int.cluster1.redhat.com/192.168.122.2',
+    ]
+
+    content2, entries2 = _update(content, "cluster2", "192.168.123.2")
+    assert entries2 == [
+        b'server=/*.api.cluster1.redhat.com/*.api-int.cluster1.redhat.com/#',
+        b'server=/*.api.cluster2.redhat.com/*.api-int.cluster2.redhat.com/#',
+        b'server=/apps.cluster1.redhat.com/api.cluster1.redhat.com/api-int.cluster1.redhat.com/192.168.122.2',
+        b'server=/apps.cluster2.redhat.com/api.cluster2.redhat.com/api-int.cluster2.redhat.com/192.168.123.2',
+    ]
+
+    content, entries = _update(b"", "cluster1", None)
+    assert entries == []


### PR DESCRIPTION
Since commit [1], libvirt's dnsmasq used "--resolvconf" option to
"/etc/resolv.conf.cda-orig". The purpose was to avoid a DNS loop. That
happened because "/etc/resolv.conf" contains "nameserver 127.0.0.1", and
the local dnsmasq.service will forward "{cluster}.redhat.com" names to
the API host (see "/etc/dnsmasq.d/cda-cluster-{cluster_name}.conf"
file). The API host inside libvirt then can forward those requests back
to libvirt's dnsmasq. Which forwards to the local dnsmasq.service. And
so on. The result are messages like

  Maximum number of concurrent DNS queries reached (max: 150)

The  problem was that we must not forward all of "{cluster}.redhat.com"
to the cluster's DNS server. We only should forward "apps", "api" and
"api-int" names. The proper solution is a more fine grained selection
of domains.

Revert the change [1] to libvirt's dnsmasq and fix the resolution loop for
the local dnsmasq.service.

While at it, no longer use the "cda-cluster-{cluster_name}.conf" file
but switch to "/etc/dnsmasq.d/servers/cda-servers.conf". The benefit of
the servers file is that it can be reloaded via SIGHUP. The minor
downside is, that we no longer write one file per cluster, which we
previously could do without parsing the existing file. Now we need to
parse the file during update. Another benefit is that this file now
contains domain configuration separate from the other dnsmasq config. It
could therefore theoretically be also used by libvirt's dnsmasq
instance.

Also, make sure the dnsutil API is thread safe by adding some locks.

[1] https://github.com/bn222/cluster-deployment-automation/commit/03f05ec595ee9e6b09b1b3fafc43f5075ff92f24
