### PR TITLE
[th/log-thread-id] logger: show the thread ID in the logging output

### DIFF
--- a/logger.py
+++ b/logger.py
@@ -36,7 +36,7 @@ def configure_logger(lvl: Optional[int] = None) -> ExtendedLogger:
 
     logger.setLevel(lvl)
 
-    fmt = "%(asctime)s %(levelname)s: %(message)s"
+    fmt = "%(asctime)s %(levelname)s [th:%(thread)s]: %(message)s"
     datefmt = "%Y-%m-%d %H:%M:%S"
     formatter = logging.Formatter(fmt, datefmt)
 


### PR DESCRIPTION
Since CDA runs multiple threads, it is confusing to understand which thread logs what. Show the thread id for each logging line.
```
$ CDA_LOG_LEVEL=debug python -c 'import host; print(host.LocalHost().run("echo -n hello world").out)'
2024-05-16 17:55:11 DEBUG [th:140209788324736]: new instance for localhost
2024-05-16 17:55:11 DEBUG [th:140209788324736]: running command echo -n hello world on localhost
2024-05-16 17:55:11 DEBUG [th:140209788324736]: (returncode: 0, error: )
hello world
```