### PR TITLE
[th/sriov-local-build-2] build sriov-network-operator from master

### DIFF
--- a/clustersConfig.py
+++ b/clustersConfig.py
@@ -38,6 +38,15 @@ class ExtraConfigArgs:
     # Time to wait for the builders to roll out.
     custom_ovn_build_timeout: str = "20m"
 
+    # With "sriov_network_operator", if true build the container images locally
+    # and push them to the internal container registry of openshift.
+    #
+    # You will need authentication for fetching build containers.
+    # Get the login token from [1]. Then `podman login registry.ci.openshift.org`
+    # or create "$XDG_RUNTIME_DIR/containers/auth.json".
+    # [1] https://oauth-openshift.apps.ci.l2s4.p1.openshiftapps.com/oauth/token/request
+    sriov_network_operator_local: bool = False
+
 
 @dataclass
 class NodeConfig:

--- a/clustersConfig.py
+++ b/clustersConfig.py
@@ -45,6 +45,10 @@ class ExtraConfigArgs:
     # Get the login token from [1]. Then `podman login registry.ci.openshift.org`
     # or create "$XDG_RUNTIME_DIR/containers/auth.json".
     # [1] https://oauth-openshift.apps.ci.l2s4.p1.openshiftapps.com/oauth/token/request
+    #
+    # If enabled, an existing "/root/sriov-network-operator" directory is not
+    # wiped and you can prepare there the version you want to build and
+    # install.
     sriov_network_operator_local: bool = False
 
 

--- a/common.py
+++ b/common.py
@@ -460,3 +460,20 @@ def atomic_write(
                 os.unlink(tmp)
             except IOError:
                 pass
+
+
+def build_sriov_network_operator_check_permissions() -> bool:
+    # To build sriov_network_operator, we must be able to pull build images
+    # from registry.ci.ipenshift.org. See [1].
+    #
+    # For that, you must get a token from [2] and issue `podman login
+    # registry.ci.openshift.org`.
+    #
+    # This function tries to fetch such an image, to determine whether we have
+    # permissions.
+    #
+    # [1] https://github.com/openshift/sriov-network-operator/blob/34f3e5f934ca72eae57667d7a9185f5af47aea3a/Dockerfile.rhel7#L1
+    # [2] https://oauth-openshift.apps.ci.l2s4.p1.openshiftapps.com/oauth/token/request
+    rsh = host.LocalHost()
+    ret = rsh.run("podman pull registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16")
+    return ret.success()

--- a/extraConfigSriov.py
+++ b/extraConfigSriov.py
@@ -13,18 +13,26 @@ from logger import logger
 from clustersConfig import ExtraConfigArgs
 
 
+def _sno_repo_setup(repo_dir: str, *, repo_wipe: bool = True) -> None:
+    exists = os.path.exists(repo_dir)
+    if exists and not repo_wipe:
+        return
+
+    if exists:
+        shutil.rmtree(repo_dir)
+
+    url = "https://github.com/openshift/sriov-network-operator.git"
+    logger.info(f"Cloning repo {url} to {repo_dir}")
+    Repo.clone_from(url, repo_dir, branch='master')
+
+
 def ExtraConfigSriov(cc: ClustersConfig, cfg: ExtraConfigArgs, futures: dict[str, Future[Optional[host.Result]]]) -> None:
     [f.result() for (_, f) in futures.items()]
     client = K8sClient(cc.kubeconfig)
     lh = host.LocalHost()
     repo_dir = "/root/sriov-network-operator"
-    url = "https://github.com/openshift/sriov-network-operator.git"
 
-    if os.path.exists(repo_dir):
-        shutil.rmtree(repo_dir)
-
-    logger.info(f"Cloning repo to {repo_dir}")
-    Repo.clone_from(url, repo_dir, branch='master')
+    _sno_repo_setup(repo_dir)
 
     cur_dir = os.getcwd()
     os.chdir(repo_dir)

--- a/extraConfigSriov.py
+++ b/extraConfigSriov.py
@@ -152,7 +152,10 @@ def _sno_make_deploy(
 def ExtraConfigSriov(cc: ClustersConfig, cfg: ExtraConfigArgs, futures: dict[str, Future[Optional[host.Result]]]) -> None:
     [f.result() for (_, f) in futures.items()]
     repo_dir = "/root/sriov-network-operator"
-    _sno_repo_setup(repo_dir)
+    _sno_repo_setup(
+        repo_dir,
+        repo_wipe=not cfg.sriov_network_operator_local,
+    )
     _sno_make_deploy(
         repo_dir,
         kubeconfig=cc.kubeconfig,

--- a/host.py
+++ b/host.py
@@ -447,6 +447,15 @@ class Host:
     def hostname(self) -> str:
         return self._hostname
 
+    def home_dir(self, *path_components: str) -> str:
+        ret = self.run("bash -c 'echo -n ~'")
+        path = ret.out
+        if not ret.success() or not path or path[0] != "/":
+            raise RuntimeError("Failure getting home directory")
+        if path_components:
+            path = os.path.join(path, *path_components)
+        return path
+
     def exists(self, path: str) -> bool:
         return self.run(f"stat {path}", logging.DEBUG).returncode == 0
 

--- a/reglocal.py
+++ b/reglocal.py
@@ -1,0 +1,134 @@
+import json
+import shlex
+import os
+
+import host
+import k8sClient
+
+CONTAINER_NAME = "local-container-registry"
+
+
+def _dir_name(rsh: host.Host) -> str:
+    return rsh.home_dir(".local-container-registry")
+
+
+def _hostname(rsh: host.Host) -> str:
+    ret = rsh.run("hostname -f")
+    h = ret.out.strip()
+    if not ret.success() or not h:
+        raise RuntimeError("Failure to get hostname")
+    return h
+
+
+def ensure_running(rsh: host.Host, *, delete_all: bool = False, listen_port: int = 5000) -> tuple[str, str, int, str]:
+    dir_name = _dir_name(rsh)
+    hostname = _hostname(rsh)
+
+    ret = rsh.run(shlex.join(["podman", "inspect", CONTAINER_NAME, "--format", "{{.Id}}"]))
+
+    if ret.success() and rsh.run(shlex.join(['test', '-d', dir_name])).success():
+        if not delete_all:
+            return dir_name, hostname, listen_port, ret.out.strip()
+        _delete_all(rsh, dir_name)
+
+    dir_name_certs = os.path.join(dir_name, "certs")
+    dir_name_data = os.path.join(dir_name, "data")
+    dir_name_auth = os.path.join(dir_name, "auth")
+
+    rsh.run(shlex.join(["mkdir", "-p", dir_name]))
+    rsh.run(shlex.join(["mkdir", "-p", dir_name_certs]))
+    rsh.run(shlex.join(["mkdir", "-p", dir_name_data]))
+    rsh.run(shlex.join(["mkdir", "-p", dir_name_auth]))
+
+    rsh.run_or_die(
+        shlex.join(
+            [
+                "openssl",
+                "req",
+                "-newkey",
+                "rsa:4096",
+                "-nodes",
+                "-sha256",
+                "-keyout",
+                os.path.join(dir_name_certs, "domain.key"),
+                "-x509",
+                "-days",
+                "365",
+                "-out",
+                os.path.join(dir_name_certs, "domain.crt"),
+                "-subj",
+                f"/CN={hostname}",
+                "-addext",
+                f"subjectAltName = DNS:{hostname}",
+            ]
+        )
+    )
+
+    # We need both domain.crt and domain.cert for `podman push --cert-dir` to work.
+    rsh.run(shlex.join(["ln", "-snf", "domain.crt", os.path.join(dir_name_certs, "domain.cert")]))
+
+    ret = rsh.run_or_die(
+        shlex.join(
+            [
+                "podman",
+                "run",
+                "--name",
+                CONTAINER_NAME,
+                "-p",
+                f"{listen_port}:5000",
+                "-v",
+                f"{dir_name_data}:/var/lib/registry:z",
+                "-v",
+                f"{dir_name_auth}:/auth:z",
+                "-v",
+                f"{dir_name_certs}:/certs:z",
+                "-e",
+                "REGISTRY_HTTP_TLS_CERTIFICATE=/certs/domain.crt",
+                "-e",
+                "REGISTRY_HTTP_TLS_KEY=/certs/domain.key",
+                "-e",
+                "REGISTRY_COMPATIBILITY_SCHEMA1_ENABLED=true",
+                f"--annotation=LOCAL_CONTAINER_REGISTRY_HOSTNAME={hostname}",
+                "-d",
+                "docker.io/library/registry:latest",
+            ]
+        )
+    )
+
+    return dir_name, hostname, listen_port, ret.out.strip()
+
+
+def _delete_all(rsh: host.Host, dir_name: str) -> None:
+    rsh.run(shlex.join(["podman", "rm", "-f", CONTAINER_NAME]))
+    rsh.run(shlex.join(["rm", "-rf", dir_name]))
+
+
+def delete_all(rsh: host.Host) -> None:
+    _delete_all(rsh, _dir_name(rsh))
+
+
+def ocp_trust(client: k8sClient.K8sClient, dir_name: str, hostname: str, listen_port: int) -> None:
+    cm_name = f"local-container-registry-{hostname}"
+
+    crt_file = os.path.join(dir_name, 'certs/domain.crt')
+    if not os.path.isfile(crt_file):
+        # This function can only operate locally, like K8sClient. The file must
+        # exist.
+        raise RuntimeError(f"Certificate file {crt_file} does not exist!")
+
+    client.oc(f"delete configmap -n openshift-config {shlex.quote(cm_name)}")
+    client.oc(
+        shlex.join(
+            [
+                "create",
+                "configmap",
+                "-n",
+                "openshift-config",
+                cm_name,
+                f"--from-file={hostname}..{listen_port}={crt_file}",
+            ]
+        ),
+    )
+
+    data = {"spec": {"additionalTrustedCA": {"name": cm_name}}}
+    client.oc(f"patch image.config.openshift.io/cluster --patch {shlex.quote(json.dumps(data))} --type=merge")


### PR DESCRIPTION
add option `sriov_network_operator_local` for building containers of `sriov-network-operator`.

This is a re-spin of https://github.com/bn222/cluster-deployment-automation/pull/168, but without the API changes that that branch required.