### PR TITLE
[th/host-unused-import] host: fix flake8 warning about unused import

### DIFF
--- a/host.py
+++ b/host.py
@@ -9,7 +9,8 @@ import shutil
 import sys
 import logging
 import tempfile
-from typing import Optional, Union, Any
+from typing import Optional
+from typing import Union
 from functools import lru_cache
 from ailib import Redfish
 import paramiko


### PR DESCRIPTION
```
./host.py:12:1: F401 'typing.Any' imported but unused
```