### PR TITLE
Add post config step to start microshift on ACC

### DIFF
--- a/extraConfigMicroshift.py
+++ b/extraConfigMicroshift.py
@@ -1,0 +1,97 @@
+import time
+from concurrent.futures import Future
+from typing import Optional
+from logger import logger
+from clustersConfig import ClustersConfig
+from clustersConfig import ExtraConfigArgs
+import host
+
+
+def wait_for_microshift(acc: host.Host, kubeconfig: str) -> None:
+    logger.info("Waiting for microshift service to start")
+    for attempt in range(1, 21):
+        ret = acc.run(f"oc get no --kubeconfig {kubeconfig}")
+        if ret.returncode == 0:
+            if "Ready" in ret.out:
+                logger.info("Verified microshift node is ready")
+                break
+        else:
+            logger.info(f"Microshift endpoint is not yet available, retrying, {ret.err}")
+        logger.info(f"Microshift node not yet ready, attempt {attempt}")
+        time.sleep(60)
+    else:
+        logger.error_and_exit(f"Node failed to reach ready state {ret.returncode}: {ret.out} {ret.err}")
+
+
+def ExtraConfigMicroshift(cc: ClustersConfig, cfg: ExtraConfigArgs, futures: dict[str, Future[Optional[host.Result]]]) -> None:
+    [f.result() for (_, f) in futures.items()]
+    logger.info("Running post config step to start Microshift on the IPU")
+
+    # Validate args
+    ipu_node = cc.masters[0]
+
+    # Enable NAT / IP forwarding on host to provide internet connectivity to ACC
+    lh = host.LocalHost()
+    cc.prepare_external_port()
+    wan_interface = cc.external_port
+    lan_interface = cc.network_api_port
+    ip_tables = "/sbin/iptables"
+
+    logger.info(f"Setting up ip forwarding on {lh.hostname()} from {lan_interface} to {wan_interface}")
+
+    lh.run_or_die("/bin/echo 1 > /proc/sys/net/ipv4/ip_forward")
+    lh.run_or_die(f"{ip_tables} -t nat -A POSTROUTING -o {lan_interface} -j MASQUERADE")
+    lh.run_or_die(f"{ip_tables} -A FORWARD -i {lan_interface} -o {wan_interface} -m state --state RELATED,ESTABLISHED -j ACCEPT ")
+    lh.run_or_die(f"{ip_tables} -A FORWARD -i {wan_interface} -o {lan_interface} -j ACCEPT")
+    lh.run_or_die(f"{ip_tables} -t nat -A POSTROUTING -o {wan_interface} -j MASQUERADE")
+    lh.run_or_die(f"{ip_tables} -A FORWARD -i {wan_interface} -o {lan_interface} -m state --state RELATED,ESTABLISHED -j ACCEPT")
+    lh.run_or_die(f"{ip_tables} -A FORWARD -i {lan_interface} -o {wan_interface} -j ACCEPT")
+
+    assert ipu_node.ip is not None
+    acc = host.Host(ipu_node.ip)
+    acc.ssh_connect("root", "redhat")
+
+    # Set up pull secret
+    logger.info(f"Copying pull secret to {acc.hostname()}:/etc/crio/openshift-pull-secret")
+    acc.copy_to("pull_secret.json", "/etc/crio/openshift-pull-secret")
+    acc.run_or_die("chown root:root /etc/crio/openshift-pull-secret")
+    acc.run_or_die("chmod 600 /etc/crio/openshift-pull-secret")
+
+    # Configure firewalld for microshift
+    logger.info("Configuring firewall for microshift")
+    acc.run_or_die("firewall-cmd --permanent --zone=trusted --add-source=10.42.0.0/16")
+    acc.run_or_die("firewall-cmd --permanent --zone=trusted --add-source=169.254.169.1")
+    acc.run_or_die("firewall-cmd --reload")
+
+    # Adjust the timeout for microshift service to ensure it starts successfully
+    acc.run_or_die("mkdir -p /etc/systemd/system/microshift.service.d/")
+    acc.write("/etc/systemd/system/microshift.service.d/override.conf", "[Service]\nTimeoutStartSec=15m")
+
+    # Check on the status of the cluster
+    kubeconfig = "/var/lib/microshift/resources/kubeadmin/kubeconfig"
+
+    # Add microshift early access repo for 4.16
+    repo = """[microshift-latest-4.16]
+name=MicroShift latest-4.16 EarlyAccess EC or RC RPMs
+baseurl=https://mirror.openshift.com/pub/openshift-v4/aarch64/microshift/ocp-dev-preview/latest-4.16/el9/os/
+enabled=1
+gpgcheck=0
+skip_if_unavailable=0
+
+
+[microshift-latest-4.16-dependencies]
+name=OpenShift Dependencies
+baseurl=https://mirror.openshift.com/pub/openshift-v4/aarch64/dependencies/rpms/4.16-el9-beta/
+enabled=1
+gpgcheck=0
+skip_if_unavailable=0"""
+
+    acc.write("/etc/yum.repos.d/microshift-canidate.repo", repo)
+
+    logger.info("Installing microshift 4.16")
+    acc.run_or_die("dnf install -y microshift microshift-multus")
+    acc.run_or_die("systemctl restart crio.service")
+    logger.info("Starting microshift")
+    acc.run("systemctl restart microshift")
+
+    wait_for_microshift(acc, kubeconfig)

--- a/extraConfigRunner.py
+++ b/extraConfigRunner.py
@@ -9,6 +9,7 @@ from extraConfigCNO import ExtraConfigCNO
 from extraConfigRT import ExtraConfigRT
 from extraConfigDualStack import ExtraConfigDualStack
 from extraConfigCX import ExtraConfigCX
+from extraConfigMicroshift import ExtraConfigMicroshift
 from clustersConfig import ClustersConfig
 from clustersConfig import ExtraConfigArgs
 from concurrent.futures import Future
@@ -40,6 +41,7 @@ class ExtraConfigRunner:
             "rt": ExtraConfigRT,
             "dualstack": ExtraConfigDualStack,
             "cx_firmware": ExtraConfigCX,
+            "microshift": ExtraConfigMicroshift,
         }
 
     def run(self, to_run: ExtraConfigArgs, futures: dict[str, Future[Optional[host.Result]]]) -> None:

--- a/host.py
+++ b/host.py
@@ -278,7 +278,7 @@ class Host:
                         logger.debug(f"{type(e).__name__} - {str(e)} for login {login.debug_details()} on host {self._hostname}")
                     time.sleep(10)
                 except Exception as e:
-                    logger.exception(f"SSH connect, login {login.debug_details()} user {login._username} on host {self._host}: {type(e).__name__} - {str(e)}")
+                    logger.exception(f"SSH connect, login {login.debug_details()} user {login._username} on host {self._hostname}: {type(e).__name__} - {str(e)}")
                     raise e
 
         raise ConnectionError(f"Failed to establish an SSH connection to {self._hostname}")


### PR DESCRIPTION
Add a post config step which will start the microshift service.

Example config:

clusters:
  - name : "iso_cluster"
    api_vip: "192.168.122.99"
    ingress_vip: "192.168.122.101"
    network_api_port: "eno12409"
    kind: "iso"
    install_iso: "http://my-server/rhel9_4.iso"
    masters:
    - name: "216-acc"
      node: "localhost"
      type: "physical"
      bmc: "my_imc_address.redhat.com"
      bmc_user: "root"
      bmc_password: "bmc_pass"
      ip: "192.168.3.16"
      mac: "00:09:00:01:03:18"
    postconfig:
    - name: "microshift"
