### PR TITLE
Add extra post step to enable/disable scheduling on master

### DIFF
--- a/clustersConfig.py
+++ b/clustersConfig.py
@@ -51,6 +51,9 @@ class ExtraConfigArgs:
     # install.
     sriov_network_operator_local: bool = False
 
+    # Custom config to the scheduler whether the masters are allowed to run workloads.
+    schedulable: bool = True
+
     def pre_check(self) -> None:
         if self.sriov_network_operator_local:
             if self.name != "sriov_network_operator":

--- a/extraConfigMastersSchedulable.py
+++ b/extraConfigMastersSchedulable.py
@@ -1,0 +1,24 @@
+from clustersConfig import ClustersConfig
+from k8sClient import K8sClient
+from concurrent.futures import Future
+from typing import Optional
+from logger import logger
+from clustersConfig import ExtraConfigArgs
+import host
+
+
+def ExtraConfigMastersSchedulable(cc: ClustersConfig, cfg: ExtraConfigArgs, futures: dict[str, Future[Optional[host.Result]]]) -> None:
+    [f.result() for (_, f) in futures.items()]
+    schedulable = "true" if cfg.schedulable else "false"
+    logger.info(f"Running post config step to set \"mastersSchedulable\" to \"{schedulable}\".")
+    iclient = K8sClient(cc.kubeconfig)
+
+    iclient.oc_run_or_die(f"patch scheduler cluster --type merge -p '{{\"spec\":{{\"mastersSchedulable\":{schedulable}}}}}'")
+
+
+def main() -> None:
+    pass
+
+
+if __name__ == "__main__":
+    main()

--- a/extraConfigRunner.py
+++ b/extraConfigRunner.py
@@ -5,6 +5,7 @@ from extraConfigDpuInfra import ExtraConfigDpuInfra, ExtraConfigDpuInfra_NewAPI
 from extraConfigOvnK import ExtraConfigOvnK
 from extraConfigCustomOvn import ExtraConfigCustomOvn
 from extraConfigImageRegistry import ExtraConfigImageRegistry
+from extraConfigMastersSchedulable import ExtraConfigMastersSchedulable
 from extraConfigCNO import ExtraConfigCNO
 from extraConfigRT import ExtraConfigRT
 from extraConfigDualStack import ExtraConfigDualStack
@@ -42,6 +43,7 @@ class ExtraConfigRunner:
             "dualstack": ExtraConfigDualStack,
             "cx_firmware": ExtraConfigCX,
             "microshift": ExtraConfigMicroshift,
+            "masters_schedulable": ExtraConfigMastersSchedulable,
         }
 
     def run(self, to_run: ExtraConfigArgs, futures: dict[str, Future[Optional[host.Result]]]) -> None:


### PR DESCRIPTION
Add extra post config step that allows to specify whether workloads could be scheduled on master.