### PR TITLE
[th/build-images] use separate images for sriov-network-operator

### DIFF
--- a/common.py
+++ b/common.py
@@ -12,6 +12,7 @@ import host
 from logger import logger
 import json
 import os
+import re
 import glob
 import socket
 import tempfile
@@ -538,3 +539,10 @@ def git_repo_setup(repo_dir: str, *, repo_wipe: bool = True, url: str, branch: s
 
     logger.info(f"Cloning repo {url} to {repo_dir}")
     Repo.clone_from(url, repo_dir, branch=branch)
+
+
+def extract_version_or_panic(version: str) -> str:
+    v, number_of_subs_made = re.subn("^([0-9]+[.][0-9]+\\b).*$", "\\1", version)
+    if number_of_subs_made == 1:
+        return v
+    logger.error_and_exit(f"unsupported version \"{version}\"")


### PR DESCRIPTION
`make deploy` of sriov-network-operator would install 8 images that were previously hosted on quay.io.

With "sriov_network_operator_local: True" we would rebuild 3 of them, and push them to a local registry. But the other 5 are still coming from quay.io.

Recently, those repositories from quay.io were removed. `make deploy` no longer works.

Add a script "contrib/scripts/build-images.sh" for building those images and push them to a registry. Also, images were build and pushed to quay.io/thaller.

Use those images by default.

The user can still overwrite each image by setting the respective environment variable.

Examples:

A.1) build upstream and push to quay.io:
```
  $ ./contrib/scripts/build-images.sh "" "" "quay.io/$USER"
```
B.1) run local container registry:
```
  $ CDA_LOG_LEVEL=debug \
    python -c 'if 1:
            import reglocal, host

            reg = reglocal.ensure_running(host.LocalHost(), delete_all=False)
            print(f"result: {reg}")
            print(f"registry: {reg[1]}:{reg[2]}")
            print(f"cert-dir: PODMAN_PUSH_ARGS=\"--cert-dir={reg[0]}/certs\"")
        '
```
B.2) build upstream and push to local registry from B.1):
```
  $ DOWNSTREAM=1 \
    PODMAN_PUSH_ARGS="--cert-dir=$HOME/.local-container-registry/certs" \
    ./contrib/scripts/build-images.sh "" "" "$(hostname -f):5000"
```

---

I pushed upstream (using `Dockerfile`) images to https://quay.io/organization/thaller, for 4.14, 4.15 and 4.16.

Except for `OVS_CNI_IMAGE`, which is at quay.io/kubevirt/ovs-cni-plugin and still works.

Per Red Hat Policy, we are probably not allowed to publish the `Dockerfile.rhel` and `Dockerfile.rhel7` images, as they depend on an internal build image.

To build a downstream variant (using `Dockerfile.rhel`), do something like
```
      OCP_RELEASE=4.16

      CDA_LOG_LEVEL=debug \
      python -c 'if 1:
              import reglocal, host

              reg = reglocal.ensure_running(host.LocalHost(), delete_all=False)
              print(f"result: {reg}")
              print(f"registry: {reg[1]}:{reg[2]}")
              print(f"cert-dir: PODMAN_PUSH_ARGS=\"--cert-dir={reg[0]}/certs\"")
          '
      REGISTRY="$(hostname -f):5000"

      DOWNSTREAM=1 \
      PODMAN_PUSH_ARGS="--cert-dir=$HOME/.local-container-registry/certs" \
      ./contrib/scripts/build-images.sh "$OCP_RELEASE" "sriov-network-device-plugin" "$REGISTRY"

      export SRIOV_DEVICE_PLUGIN_IMAGE="$REGISTRY/sriov-network-device-plugin:$OCP_RELEASE"
```