### PR TITLE
Changes to DPU-Operator requires new resource name

### DIFF
--- a/manifests/dpu/dpu_nad.yaml
+++ b/manifests/dpu/dpu_nad.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sriov-net1
   namespace: default
   annotations:
-    k8s.v1.cni.cncf.io/resourceName: intel.com/intel_sriov_netdevice
+    k8s.v1.cni.cncf.io/resourceName: openshift.io/dpu
 spec:
   config: '{
   "type": "dpu-cni",


### PR DESCRIPTION
Resource name changed to "openshift.io/dpu"
From this commit: https://github.com/openshift/dpu-operator/pull/85