### PR TITLE
Print proper error message when updating go version

### DIFF
--- a/extraConfigDpu.py
+++ b/extraConfigDpu.py
@@ -130,7 +130,9 @@ def ensure_go_installed(host: host.Host) -> None:
         host.run_or_die("echo 'export PATH=$PATH:/usr/local/go/bin' >> /etc/profile")
         host.run_or_die("echo 'export PATH=$PATH:/usr/local/go/bin' > /etc/profile.d/go.sh")
         host.run_or_die("chmod +x /etc/profile.d/go.sh")
-    host.run_or_die("go version")
+    ret = host.run("go version")
+    if not ret.success():
+        logger.error_and_exit("Unable to update PATH for a running process, run 'export PATH=$PATH:/usr/local/go/bin' and try again")
 
 
 def copy_local_registry_certs(host: host.Host, path: str) -> None:


### PR DESCRIPTION
After installing the required version of go for building the dpu operator, the PATH for the current process will not be updated.

We could either manually hand the updated environment to every future call to run, however this is messy and puts a burden on the caller.

A cleaner solution might be to just error out and instruct the user to re-start the process with the proper PATH