### PR TITLE
Fix CI issue for SNO Config Daemon on version >= "4.16.0"

### DIFF
--- a/common.py
+++ b/common.py
@@ -546,3 +546,8 @@ def extract_version_or_panic(version: str) -> str:
     if number_of_subs_made == 1:
         return v
     logger.error_and_exit(f"unsupported version \"{version}\"")
+
+
+def calculate_elapsed_time(start: float, end: float) -> tuple[int, int]:
+    minutes, seconds = divmod(int(end - start), 60)
+    return minutes, seconds


### PR DESCRIPTION
extraConfigSriov.py:
 - Fixed CI issue by waiting for all pods in the SNO to be ready rather than wait for the crd since it is not provided by default after version 4.16.0.
 - Made the change backwards compatible by keeping "wait_for_crd" if the version is older than 4.16.0.
 common.py:
 - Added a helper function to parse version numbers into tuple to be used to compare version numbers.
 - Added a function to calculate the elapsed time.

K8client.py:
 - Added a function that waits for all pods of a namespace to be ready, it retries
until ready up to 10 times.
 - Added elapsed time of waiting for all pods to the above function.

 All changes tested with the CI, which deployed successfully.