### PR TITLE
libvirt: Use Libvirt modular instead of monolithic

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ dnf install -y python3.11
 python3.11 -m venv ocp-venv
 source ocp-venv/bin/activate
 ./dependencies.sh
-systemctl enable --now libvirtd
 usermod -a -G root qemu
 
 # Ensure having a suitable SSH key

--- a/assistedInstallerService.py
+++ b/assistedInstallerService.py
@@ -14,6 +14,7 @@ from requests import get as get_url
 from logger import logger
 import host
 import common
+from libvirt import Libvirt
 
 
 def load_url_or_file(url_or_file: str) -> str:
@@ -356,8 +357,8 @@ class AssistedInstallerService:
         lh = host.LocalHost()
         if not common.ip_links(lh, ifname="virbr0"):
             logger.info("Can't find virbr0. Trying to restart libvirt.")
-            cmd = "systemctl start libvirtd"
-            lh.run(cmd)
+            libvirt = Libvirt(lh)
+            libvirt.configure()
             cmd = "virsh net-start default"
             lh.run(cmd)
 
@@ -366,7 +367,7 @@ class AssistedInstallerService:
             time.sleep(5)
 
         if not common.ip_links(lh, ifname="virbr0"):
-            logger.error_and_exit("Can't find virbr0. Make sure that libvirtd is running.")
+            logger.error_and_exit("Can't find virbr0. Make sure that libvirt is running.")
 
     def wait_for_api(self) -> None:
         self._ensure_libvirt_running()

--- a/clusterDeployer.py
+++ b/clusterDeployer.py
@@ -25,6 +25,7 @@ import dnsutil
 from virshPool import VirshPool
 from arguments import PRE_STEP, WORKERS_STEP, MASTERS_STEP, POST_STEP
 import isoCluster
+from libvirt import Libvirt
 
 
 def match_to_proper_version_format(version_cluster_config: str) -> str:
@@ -559,10 +560,10 @@ class ClusterDeployer:
         hosts.add([HostsEntry(entry_type='ipv4', address=api_vip, names=[api_name])])
         hosts.write()
 
-        # libvirtd also runs dnsmasq, and dnsmasq reads /etc/hosts.
-        # For that reason, restart libvirtd to re-read the changes.
-        lh = host.LocalHost()
-        lh.run("systemctl restart libvirtd")
+        # libvirt also runs dnsmasq, and dnsmasq reads /etc/hosts.
+        # For that reason, restart libvirt to re-read the changes.
+        libvirt = Libvirt(host.LocalHost())
+        libvirt.restart()
 
     def update_dnsmasq(self, *, setup: bool = True) -> None:
         cluster_name = self._cc.name

--- a/libvirt.py
+++ b/libvirt.py
@@ -1,0 +1,42 @@
+import host
+from logger import logger
+
+MODULAR_SERVICES = ["qemu", "interface", "network", "nodedev", "nwfilter", "secret", "storage"]
+MODULAR_SOCKET_SUFFIXES = [".socket", "-ro.socket", "-admin.socket"]
+MONOLITHIC_SOCKET_SUFFIXES = [".socket", "-ro.socket", "-admin.socket", "-tcp.socket", "-tls.socket"]
+
+
+class Libvirt:
+    """
+    Wrapper on top of the Libvirt service.
+
+    It can be running locally or remote.
+    """
+
+    hostconn: host.Host
+
+    def __init__(self, h: host.Host) -> None:
+        self.hostconn = h
+
+    def configure(self) -> None:
+        logger.info("Configuring Libvirt modules")
+
+        # Stop and disable the monolithic Libvirt service
+        self.hostconn.run_or_die("systemctl stop libvirtd.service")
+        self._run_per_suffix("systemctl stop", "libvirtd", MONOLITHIC_SOCKET_SUFFIXES)
+        self.hostconn.run_or_die("systemctl disable libvirtd.service")
+        self._run_per_suffix("systemctl disable", "libvirtd", MONOLITHIC_SOCKET_SUFFIXES)
+
+        for service in MODULAR_SERVICES:
+            self.hostconn.run_or_die(f"systemctl enable virt{service}d.service")
+            self._run_per_suffix("systemctl enable", f"virt{service}d", MODULAR_SOCKET_SUFFIXES)
+            self._run_per_suffix("systemctl start", f"virt{service}d", MODULAR_SOCKET_SUFFIXES)
+
+    def restart(self) -> None:
+        for service in MODULAR_SERVICES:
+            self.hostconn.run_or_die(f"systemctl restart virt{service}d.service")
+            self._run_per_suffix("systemctl restart", f"virt{service}d", MODULAR_SOCKET_SUFFIXES)
+
+    def _run_per_suffix(self, cmd: str, service: str, suffixes: list[str]) -> None:
+        for suffix in suffixes:
+            self.hostconn.run_or_die(f"{cmd} {service}{suffix}")


### PR DESCRIPTION
The Libvirt monolithic apporach was replaced in favor of modular approach. Use the modular services instead of the monolithic. At the same time make sure that the monolithic is not running at the same time with modular services.