### PR TITLE
[th/fix-typing-gspread] clusterInfo: fix typing errors for gspread module

### DIFF
--- a/clusterInfo.py
+++ b/clusterInfo.py
@@ -26,10 +26,10 @@ def read_sheet() -> list[dict[str, str]]:
         logger.info("Missing credentials.json while using templated config file")
         sys.exit(-1)
     credentials = ServiceAccountCredentials.from_json_keyfile_name(cred_path, scopes)
-    file = gspread.authorize(credentials)
+    file = gspread.auth.authorize(credentials)
     sheet = file.open("ANL lab HW enablement clusters and connections")
-    sheet = sheet.sheet1
-    return [{k: str(v) for k, v in record.items()} for record in sheet.get_all_records()]
+    sheet1 = sheet.sheet1
+    return [{k: str(v) for k, v in record.items()} for record in sheet1.get_all_records()]
 
 
 def load_all_cluster_info() -> dict[str, ClusterInfo]:


### PR DESCRIPTION
```
$ mypy --strict --config-file mypy.ini .
clusterInfo.py:29: error: Module "gspread" does not explicitly export attribute "authorize"  [attr-defined]
clusterInfo.py:31: error: Incompatible types in assignment (expression has type "Worksheet", variable has type "Spreadsheet")  [assignment]
clusterInfo.py:32: error: "Spreadsheet" has no attribute "get_all_records"  [attr-defined]
Found 3 errors in 1 file (checked 45 source files)
```