### PR TITLE
[th/base-deployer] add a BaseDeployer class for common functionality of ClusterDeployer+IsoDeployer

### DIFF
--- a/clusterDeployer.py
+++ b/clusterDeployer.py
@@ -46,8 +46,6 @@ class BaseDeployer(abc.ABC):
         self.steps = tuple(steps)
 
     def _prepost_config(self, to_run: ExtraConfigArgs) -> None:
-        if not to_run:
-            return
         self._extra_config.run(to_run, self._futures)
 
     def _preconfig(self) -> None:

--- a/clusterDeployer.py
+++ b/clusterDeployer.py
@@ -638,13 +638,7 @@ class IsoDeployer(BaseDeployer):
             logger.error("Masters must be of length one for deploying from iso")
             sys.exit(-1)
         self._master = self._cc.masters[0]
-
-        def empty() -> Future[Optional[host.Result]]:
-            f: Future[Optional[host.Result]] = Future()
-            f.set_result(None)
-            return f
-
-        self._futures[self._master.name] = empty()
+        self._futures[self._master.name] = common.empty_future(host.Result)
         self._validate()
 
     def _validate(self) -> None:

--- a/clusterNode.py
+++ b/clusterNode.py
@@ -30,13 +30,8 @@ class ClusterNode:
     dynamic_ip: Optional[str] = None
 
     def __init__(self, config: NodeConfig):
-        def empty() -> Future[Optional[host.Result]]:
-            f: Future[Optional[host.Result]] = Future()
-            f.set_result(None)
-            return f
-
         self.config = config
-        self.future = empty()
+        self.future = common.empty_future(host.Result)
 
     def ip(self) -> str:
         if self.config.ip is not None:

--- a/common.py
+++ b/common.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 import dataclasses
 import ipaddress
 from typing import Optional, TypeVar, Iterator, Type
+from concurrent.futures import Future
 import contextlib
 from types import TracebackType
 import http.server
@@ -551,3 +552,9 @@ def extract_version_or_panic(version: str) -> str:
 def calculate_elapsed_time(start: float, end: float) -> tuple[int, int]:
     minutes, seconds = divmod(int(end - start), 60)
     return minutes, seconds
+
+
+def empty_future(result_type: type[T]) -> Future[Optional[T]]:
+    f: Future[Optional[T]] = Future()
+    f.set_result(None)
+    return f


### PR DESCRIPTION
`IsoDeployer` subclasses `ClusterDeployer` but it shortcuts most of the functionality from the base class (including `ClusterDeployer.__init__()`). This makes it harder to understand which part of (the non-trivial) `ClusterDeployer` is actually in use.

Instead, add a `BaseDeployer` base class for both, and move the common code there.