### PR TITLE
Configure dpu repo

### DIFF
--- a/clustersConfig.py
+++ b/clustersConfig.py
@@ -57,6 +57,8 @@ class ExtraConfigArgs:
     rebuild_dpu_operators_images: bool = True
 
     dpu_net_interface: Optional[str] = "ens2f0"
+    dpu_operator_repo: str = "https://github.com/openshift/dpu-operator.git"
+    dpu_operator_branch: str = "main"
 
     def pre_check(self) -> None:
         if self.sriov_network_operator_local:


### PR DESCRIPTION
    Make dpu operator repo / branch configurable
    
    Allow users to specify the repo/branch they want to build and deploy
    from in the CDA config file.
    
    i.e.
        - name: "dpu_operator_dpu"
          dpu_operator_repo:
    "https://github.com/SalDaniele/cluster-deployment-automation.git"
          dpu_operator_branch: "my_branch"