### PR TITLE
Move cluster monitoring config into separate post step

### DIFF
--- a/clusterDeployer.py
+++ b/clusterDeployer.py
@@ -234,8 +234,6 @@ class ClusterDeployer(BaseDeployer):
                 logger.error_and_exit("Masters must be of length one for deploying microshift")
         if POST_STEP in self.steps:
             self._postconfig()
-            cmd = "apply -f manifests/monitoring-config.yaml"
-            self.client().oc_run_or_die(cmd)
         else:
             logger.info("Skipping post configuration.")
 

--- a/extraConfigMonitoring.py
+++ b/extraConfigMonitoring.py
@@ -1,0 +1,23 @@
+from clustersConfig import ClustersConfig
+from k8sClient import K8sClient
+from concurrent.futures import Future
+from typing import Optional
+from logger import logger
+from clustersConfig import ExtraConfigArgs
+import host
+
+
+def ExtraConfigMonitoring(cc: ClustersConfig, cfg: ExtraConfigArgs, futures: dict[str, Future[Optional[host.Result]]]) -> None:
+    [f.result() for (_, f) in futures.items()]
+    logger.info("Running post config step to apply monitoring-config.yaml.")
+    iclient = K8sClient(cc.kubeconfig)
+
+    iclient.oc_run_or_die("apply -f manifests/monitoring-config.yaml")
+
+
+def main() -> None:
+    pass
+
+
+if __name__ == "__main__":
+    main()

--- a/extraConfigRunner.py
+++ b/extraConfigRunner.py
@@ -6,6 +6,7 @@ from extraConfigOvnK import ExtraConfigOvnK
 from extraConfigCustomOvn import ExtraConfigCustomOvn
 from extraConfigImageRegistry import ExtraConfigImageRegistry
 from extraConfigMastersSchedulable import ExtraConfigMastersSchedulable
+from extraConfigMonitoring import ExtraConfigMonitoring
 from extraConfigCNO import ExtraConfigCNO
 from extraConfigRT import ExtraConfigRT
 from extraConfigDualStack import ExtraConfigDualStack
@@ -46,6 +47,7 @@ class ExtraConfigRunner:
             "cx_firmware": ExtraConfigCX,
             "microshift": ExtraConfigMicroshift,
             "masters_schedulable": ExtraConfigMastersSchedulable,
+            "monitoring_config": ExtraConfigMonitoring,
             "rh_subscription": ExtraConfigRhSubscription,
             "dpu_operator_host": ExtraConfigDpuHost,
             "dpu_operator_dpu": ExtraConfigDpu,


### PR DESCRIPTION
The monitorign config was applied every time after post stage. Remove the implicit config as would overwrite any config that was already on the cluster.