### PR TITLE
clusterDeployer: Fix wrong worker deployment

### DIFF
--- a/clusterDeployer.py
+++ b/clusterDeployer.py
@@ -14,7 +14,7 @@ import re
 import logging
 from assistedInstaller import AssistedClientAutomation
 import host
-from clustersConfig import ClustersConfig, ExtraConfigArgs, NodeConfig
+from clustersConfig import ClustersConfig, ExtraConfigArgs
 from k8sClient import K8sClient
 import common
 from python_hosts import Hosts, HostsEntry
@@ -324,7 +324,19 @@ class ClusterDeployer(BaseDeployer):
 
         hosts_with_masters = self._all_hosts_with_masters()
 
-        self._common_network_setup(hosts_with_masters, self._cc.master_vms())
+        # Ensure the virtual bridge is properly configured and
+        # configure DHCP entries for all masters on the local virbr and
+        # connect the workers to the physical network.
+        #
+        # NOTE: linking the network must happen before starting masters because
+        # they need to be able to access the DHCP server running on the
+        # provisioning node.
+        for h in hosts_with_masters:
+            h.configure_bridge()
+
+        self._local_host.bridge.setup_dhcp_entries(self._cc.master_vms())
+        for h in hosts_with_masters:
+            h.ensure_linked_to_network(self._local_host.bridge)
 
         # Start all masters on all hosts.
         executor = ThreadPoolExecutor(max_workers=len(self._cc.masters))
@@ -395,7 +407,19 @@ class ClusterDeployer(BaseDeployer):
         self._ai.ensure_infraenv_created(infra_env, cfg)
         hosts_with_workers = self._all_hosts_with_workers()
 
-        self._common_network_setup(hosts_with_workers, self._cc.worker_vms())
+        # Ensure the virtual bridge is properly configured and
+        # configure DHCP entries for all workers on the local virbr and
+        # connect the workers to the physical network.
+        #
+        # NOTE: linking the network must happen before starting workers because
+        # they need to be able to access the DHCP server running on the
+        # provisioning node.
+        for h in hosts_with_workers:
+            h.configure_bridge()
+
+        self._local_host.setup_dhcp_entries(self._cc.worker_vms())
+        for h in hosts_with_workers:
+            h.ensure_linked_to_network(self._local_host.bridge)
 
         executor = ThreadPoolExecutor(max_workers=len(self._cc.workers))
 
@@ -515,21 +539,6 @@ class ClusterDeployer(BaseDeployer):
                         logger.info(f"renamed {k8s_node.config.name}")
                         renamed += 1
         return renamed
-
-    def _common_network_setup(self, hosts: set[ClusterHost], vms: list[NodeConfig]) -> None:
-        # Ensure the virtual bridge is properly configured and
-        # configure DHCP entries for all vms on the local virbr and
-        # connect the vms to the physical network.
-        #
-        # NOTE: linking the network must happen before starting vms because
-        # they need to be able to access the DHCP server running on the
-        # provisioning node.
-        for h in hosts:
-            h.configure_bridge()
-        self._local_host.bridge.setup_dhcp_entries(vms)
-
-        for h in hosts:
-            h.ensure_linked_to_network(self._local_host.bridge)
 
     def _get_discovery_ign_ssh_priv_key(self, infra_env: str) -> str:
         self._ai.download_discovery_ignition(infra_env, "/tmp")


### PR DESCRIPTION
The common method didn't work for workers because the DHCP setup is sligthly different. Revert the move into common method and just simply add the link configuration for the masters.