### PR TITLE
[th/host-run-logging] host: don't strip leading spaces for logging command results

### DIFF
--- a/host.py
+++ b/host.py
@@ -373,7 +373,7 @@ class Host:
 
             out = []
             for line in iter(stdout.readline, ""):
-                logger.log(log_level, f"{self._hostname}: {line.strip()}")
+                logger.log(log_level, f"{self._hostname}: {line.rstrip()}")
                 out.append(line)
 
             err = []


### PR DESCRIPTION
We probably need to strip the trailing newline from the line, otherwise the logging lines break lines. Use str.rstrip() for that.

However, preserve the leading spaces. They align the command output and stripping them makes the log harder to read.