### PR TITLE
[th/marvell-dpu] support "kind=iso" cluster for installing RHEL on Marvell DPU

### DIFF
--- a/dpuVendor.py
+++ b/dpuVendor.py
@@ -58,11 +58,23 @@ class IpuPlugin(VendorPlugin):
         client.oc_run_or_die("create -f /tmp/vsp-ds.yaml")
 
 
-def init_vendor_plugin(h: host.Host) -> VendorPlugin:
+class MarvellDpuPlugin(VendorPlugin):
+    def __init__(self) -> None:
+        pass
+
+    def build_and_start(self, h: host.Host, client: K8sClient, registry: str) -> None:
+        # TODO: https://github.com/openshift/dpu-operator/pull/82
+        logger.warning("Setting up Marvell DPU not yet implemented")
+
+
+def init_vendor_plugin(h: host.Host, node_kind: str) -> VendorPlugin:
     # TODO: Autodetect the vendor hardware and return the proper implementation.
-    logger.info(f"Detected Intel IPU hardware on {h.hostname()}")
-    vsp_plugin = IpuPlugin()
-    return vsp_plugin
+    if node_kind == "marvell-dpu":
+        logger.info(f"Detected Marvell DPU on {h.hostname()}")
+        return MarvellDpuPlugin()
+    else:
+        logger.info(f"Detected Intel IPU hardware on {h.hostname()}")
+        return IpuPlugin()
 
 
 def extractContainerImage(dockerfile: str) -> str:

--- a/dpuVendor.py
+++ b/dpuVendor.py
@@ -8,22 +8,13 @@ from abc import ABC, abstractmethod
 
 
 class VendorPlugin(ABC):
-    @property
-    @abstractmethod
-    def repo(self) -> str:
-        raise NotImplementedError("Must implement repo property for VSP")
-
-    @property
-    @abstractmethod
-    def vsp_ds_manifest(self) -> str:
-        raise NotImplementedError("Must implement repo property for VSP")
-
     @abstractmethod
     def build_and_start(self, h: host.Host, client: K8sClient, registry: str) -> None:
         raise NotImplementedError("Must implement build_and_start() for VSP")
 
-    def render_dpu_vsp_ds(self, ipu_plugin_image: str, outfilename: str) -> None:
-        with open(self.vsp_ds_manifest) as f:
+    @staticmethod
+    def render_dpu_vsp_ds(vsp_ds_manifest: str, ipu_plugin_image: str, outfilename: str) -> None:
+        with open(vsp_ds_manifest) as f:
             j2_template = jinja2.Template(f.read())
             rendered = j2_template.render(ipu_plugin_image=ipu_plugin_image)
             logger.info(rendered)
@@ -37,18 +28,10 @@ class IpuPlugin(VendorPlugin):
         self._repo = "https://github.com/intel/ipu-opi-plugins.git"
         self._vsp_ds_manifest = "./manifests/dpu/dpu_vsp_ds.yaml.j2"
 
-    @property
-    def repo(self) -> str:
-        return self._repo
-
-    @property
-    def vsp_ds_manifest(self) -> str:
-        return self._vsp_ds_manifest
-
     def build_and_start(self, h: host.Host, client: K8sClient, registry: str) -> None:
         logger.info("Building ipu-opi-plugin")
         h.run("rm -rf /root/ipu-opi-plugins")
-        h.run_or_die(f"git clone {self.repo} /root/ipu-opi-plugins")
+        h.run_or_die(f"git clone {self._repo} /root/ipu-opi-plugins")
         ret = h.run_or_die("cat /root/ipu-opi-plugins/ipu-plugin/images/Dockerfile")
         golang_img = extractContainerImage(ret.out)
         h.run_or_die(f"podman pull docker.io/library/{golang_img}")
@@ -66,7 +49,7 @@ class IpuPlugin(VendorPlugin):
         vsp_image = f"{registry}/ipu-plugin:dpu"
         h.run_or_die(f"podman tag intel-ipuplugin:latest {vsp_image}")
 
-        self.render_dpu_vsp_ds(vsp_image, "/tmp/vsp-ds.yaml")
+        self.render_dpu_vsp_ds(self._vsp_ds_manifest, vsp_image, "/tmp/vsp-ds.yaml")
         if h.is_localhost():
             h.run_or_die(f"podman push {vsp_image}")
         else:

--- a/extraConfigDpu.py
+++ b/extraConfigDpu.py
@@ -230,7 +230,7 @@ def ExtraConfigDpu(cc: ClustersConfig, cfg: ExtraConfigArgs, futures: dict[str, 
     acc.run("systemctl disable firewalld")
 
     # Build and start vsp on DPU
-    vendor_plugin = init_vendor_plugin(acc)
+    vendor_plugin = init_vendor_plugin(acc, dpu_node.kind or "")
     if isinstance(vendor_plugin, IpuPlugin):
         # TODO: Remove when this container is properly started by the vsp
         # We need to manually start the p4 sdk container currently for the IPU plugin
@@ -281,8 +281,9 @@ def ExtraConfigDpuHost(cc: ClustersConfig, cfg: ExtraConfigArgs, futures: dict[s
     # Need to trust the registry in OCP / Microshift
     logger.info("Ensuring local registry is trusted in OCP")
 
-    h = host.Host(cc.workers[0].node)
-    vendor_plugin = init_vendor_plugin(h)
+    node = cc.workers[0]
+    h = host.Host(node.node)
+    vendor_plugin = init_vendor_plugin(h, node.kind or "")
     vendor_plugin.build_and_start(lh, client, imgReg.url())
 
     git_repo_setup(REPO_DIR, repo_wipe=True, url=DPU_OPERATOR_REPO, branch=branch)


### PR DESCRIPTION
**STATUS: this is currently blocked** waiting for https://github.com/wizhaoredhat/marvell-octeon-10-tools/pull/7 . In the meantime, you can `export CDA_MARVELL_TOOLS_IMAGE=quay.io/thaller/marvell-tools:latest`.

---

For installing RHEL on the Marvell DPU we need to use PXE boot.  Also,
we will need to access the DPU's serial console at /dev/ttyUSB0 and
/dev/ttyUSB1 on the node.

Since we already must have code running on the worker node, also expect
that the management network port of the DPU is plugged back to the host
on interface "eno4" (configurable in marvell-tools' "--dev" option).

The secondary port of the DPU expected to be connected to the
provisioning host that runs CDA. This is usually "eno2", but
configurable via "network_api_port" in cluster YAML.

To install the DPU, CDA thus runs the podman container
quay.io/wizhat/marvell-tools:latest from marvell-tools ([1]) via SSH on
the node. This is also where the majority of the logic is.

Afterwards, it proceeds in a similar way as the other "kind=iso"
cluster deployment.

Note that we have no redfish. Instead we must SSH into the worker node
to be able to run the podman container to do the PXE boot. We thus
assume that user "core" can SSH into the node. Usually this means that
you first deploy the openshift cluster and install CoreOS on the worker
node. Then you run CDA deploy to provision the Marvell DPU on the node.

For testing and development, we can set CDA_MARVELL_TOOLS_IMAGE to use
another marvell-tools container image.

[1] https://github.com/wizhaoredhat/marvell-octeon-10-tools

https://issues.redhat.com/browse/MDC-66

---

Example:

Run:
```bash
python ./cda.py -v debug ./config-marvell-dpu-host.yaml deploy
python ./cda.py -v debug ./config-marvell-dpu-dpu.yaml deploy
```

- config-marvell-dpu-host.yaml
```YAML
clusters:
  - name : "nicmodecluster"
    api_vip: "192.168.122.99"
    ingress_vip: "192.168.122.101"
    kubeconfig: /root/kubeconfig.nicmodecluster
    version: "4.16.0-nightly"
    network_api_port: "eno1"
    masters:
    - name: "nicmodecluster-master-2"
      kind: "vm"
      node: "localhost"
      ip: "192.168.122.2"
    - name: "nicmodecluster-master-3"
      kind: "vm"
      node: "localhost"
      ip: "192.168.122.3"
    - name: "nicmodecluster-master-4"
      kind: "vm"
      node: "localhost"
      ip: "192.168.122.4"
    workers:
    - name: "worker-42"
      kind: "physical"
      node: "wsfd-advnetlab42.anl.eng.bos2.dc.redhat.com"
      bmc_user: "root"
      bmc_password: "calvin"
      bmc: "10.26.16.99"
```

- config-marvell-dpu-dpu.yaml
```YAML
clusters:
  - name : "marvel_dpu_cluster"
    api_vip: "192.168.123.99"
    ingress_vip: "192.168.123.101"
    network_api_port: "eno2"
    kind: "iso"
    install_iso: "rhel:" # Causes marvell-octeon-10-tools' pxeboot to download latest RHEL9 ISO
    masters:
    - name: "marvell-dpu-42"
      # CDA must be able to ssh as user "core" into the node and run podman
      # containers as sudo.
      node: "wsfd-advnetlab42.anl.eng.bos2.dc.redhat.com"
      kind: "marvell-dpu"
      ip: "192.168.123.7"
      mac: "06:32:b1:09:0a:ee" # The MAC address is not stable. CDA configures the MAC address here.
    postconfig:
    #- name: "rh_subscription"
    #  organization_id: "${ORGANIZATION_ID}"
    #  activation_key: "${ACTIVATION_KEY}"
    - name: "microshift"
    #- name: "dpu_operator_dpu"
    #  rebuild_dpu_operators_images: false
```
