### PR TITLE
Add ability to read ISO installation details from spreadsheet

### DIFF
--- a/clusterInfo.py
+++ b/clusterInfo.py
@@ -10,6 +10,9 @@ class ClusterInfo:
         self.name = name
         self.provision_host = ""
         self.network_api_port = ""
+        self.iso = ""
+        self.organization_id = ""
+        self.activation_key = ""
         self.bmc_imc_hostnames = []  # type: list[str]
         self.ipu_mac_addresses = []  # type: list[str]
         self.workers = []  # type: list[str]
@@ -50,6 +53,9 @@ def load_all_cluster_info() -> dict[str, ClusterInfo]:
         if row["Card type"] == "IPU-Cluster":
             cluster.bmc_imc_hostnames.append(row["BMC/IMC hostname"])
             cluster.ipu_mac_addresses.append(row["MAC"])
+            cluster.iso = row["Install ISO"]
+            cluster.activation_key = row["Activation Key"]
+            cluster.organization_id = row["Organization ID"]
         if row["Provision host"] == "yes":
             cluster.provision_host = row["Name"]
             cluster.network_api_port = row["Ports"]

--- a/clustersConfig.py
+++ b/clustersConfig.py
@@ -382,6 +382,21 @@ class ClustersConfig:
             assert self._cluster_info is not None
             return self._cluster_info.network_api_port
 
+        def iso() -> str:
+            self._ensure_clusters_loaded()
+            assert self._cluster_info is not None
+            return self._cluster_info.iso
+
+        def activation_key() -> str:
+            self._ensure_clusters_loaded()
+            assert self._cluster_info is not None
+            return self._cluster_info.activation_key
+
+        def organization_id() -> str:
+            self._ensure_clusters_loaded()
+            assert self._cluster_info is not None
+            return self._cluster_info.organization_id
+
         def imc_hostname(a: int) -> str:
             self._ensure_clusters_loaded()
             assert self._cluster_info is not None
@@ -398,7 +413,10 @@ class ClustersConfig:
         template.globals['worker_number'] = worker_number
         template.globals['worker_name'] = worker_name
         template.globals['api_network'] = api_network
+        template.globals['iso'] = iso
         template.globals['bmc'] = bmc
+        template.globals['activation_key'] = activation_key
+        template.globals['organization_id'] = organization_id
         template.globals['IMC_hostname'] = imc_hostname
         template.globals['IPU_mac_address'] = ipu_mac_address
 


### PR DESCRIPTION
Since ISO installation could be pointing to internal servers, it is best that we have that information guarded in database.

Also add org id and activation key to spreadsheet as well. Earlier these were provided via jenkins credentials. Since they must be store in a special place we should add it to the database so they cannot be accessed easily. 