### PR TITLE
[th/gitignore] ignore ctags' `tags` file and various spellings for the `*venv*/` directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ pull_secret.json
 ocp-venv
 .mypy_cache
 __pycache__
-ocp-venv
+/*venv*/
 credentials.json
 bin
 build


### PR DESCRIPTION
- ctags is useful (at least to me, or anybody who likes to use this tool). It leaves a `tags` file behind, that I'd like not to see in `git status`. Ignore `/tags` file.
- allow for various venv directories, not only `ocp-venv/`. Instead, ignore `/*venv*/`. This allows to create different venvs for different python versions. Also, on other python projects, I tend to call the venv directory `./venv` (because they are not strictly ocp related). I'd like to use the same directory everywhere and don't see it in `git status`, as that is what I am used to.

In general, ignoring files that are not relevant for one or the other user (or even the majority of users), tends to be a non-issue. It would only be an issue if tomorrow a user wants to add a file `"/tags"` or `"/*venv*/"`. But even then, they still can do `git add -f FILE`, and once it's tracked by git, the gitignore no longer matters. That makes it a non-problem to ignore files somewhat eagerly.