### PR TITLE
[th/kickstart-ssh-keygen] kickstart: generate an id_ed25519 on the worker node

### DIFF
--- a/kickstart.ks.j2
+++ b/kickstart.ks.j2
@@ -23,6 +23,7 @@ cat << EOF > /etc/crio/openshift-pull-secret
 EOF
 
 mkdir -p /home/redhat/.ssh
+ssh-keygen -t ed25519 -C ocp-worker@local.local -N "" -f /root/.ssh/id_ed25519
 cat << EOF > /home/redhat/.ssh/authorized_keys
 {{ ssh_key }}
 EOF


### PR DESCRIPTION
Generate a id_ed25519 SSH key (without password) on our worker nodes. That doesn't seem harmful to have there. Despite being password-less, unless somebody intentionally uses the public key somewhere, it does nothing.

However, there is a concrete use. The marvell-tools container can deploy RHEL on a Marvell DPU on the (worker) node. That container runs on the worker node and it (configurably) adds the host's public key "/host/root/.ssh/id_ed25519.pub" into the DPU's authorized_keys. The benefit is that subsequently, you can from the worker node just ssh into root@172.131.100.100 (if you configure the 172.131.100.1 address on eno4 interface or use the IP address from the DPU's secondary interface). Otherwise, the DPU is also not secure, because the root login is well known and a root user on the node can access the DPU also via other means. It is however convenient to be able to use SSH easily.

While the current use case is only for hosts that use marvell-tools to setup a Marvell DPU, this could potentially be useful for other uses.

Also, the steps to deploy the OCP cluster and to deploy the DPU are separate. We need to have the SSH key present generated in the first step, so we can use it in the second. But the first step doesn't know it's about to deploy a worker with a Marvell DPU, which will be deployed next.