### PR TITLE
Revert "kickstart: generate an id_ed25519 on the worker node"

### DIFF
--- a/kickstart.ks.j2
+++ b/kickstart.ks.j2
@@ -23,7 +23,6 @@ cat << EOF > /etc/crio/openshift-pull-secret
 EOF
 
 mkdir -p /home/redhat/.ssh
-ssh-keygen -t ed25519 -C ocp-worker@local.local -N "" -f /root/.ssh/id_ed25519
 cat << EOF > /home/redhat/.ssh/authorized_keys
 {{ ssh_key }}
 EOF


### PR DESCRIPTION
Sorry for providing such a broken commit. Obviously insufficiently tested.

For one, we probably would need a `mkdir -p /root/.ssh`. But much worse, this kickstart.ks is only used by microshift.py, and not for our CoreOS workers. Which is obvious, we would probably need to place the SSH key there via ignition.

That seems more complicated than one line in shell, so I don't do that now.

This reverts commit abcb86d94c883cd29e6ee1acb8c8cc8ba7eebd19.