### PR TITLE
[th/virtual-bridge-teardown] virtualBridge: don't die removing DHCP range via virsh

### DIFF
--- a/virtualBridge.py
+++ b/virtualBridge.py
@@ -228,7 +228,7 @@ class VirBridge:
             if range_elem.tag:
                 xml_str = f"\"<range {xml_str}/>\""
                 cmd = f"virsh net-update default delete ip-dhcp-range {xml_str} --live --config"
-                self.hostconn.run_or_die(cmd)
+                self.hostconn.run(cmd)
 
             cmd = f"virsh net-update default add ip-dhcp-range \"{expected_dhcp_range}\" --live --config"
             self.hostconn.run_or_die(cmd)


### PR DESCRIPTION
This happens during tear-down. It should not be considered fatal.
```
  2024-08-26 03:49:55 DEBUG [th:140695601846080] (host.py:344): running command virsh net-update default delete ip-dhcp-range "<range start='192.168.122.2' end='192.168.122.254' />" --live --config on localhost
  2024-08-26 03:49:55 DEBUG [th:140695601846080] (host.py:350): (returncode: 1, error: error: Failed to update network default
  error: Requested operation is not valid: couldn't locate a matching dhcp range entry in network 'default'
  )
  2024-08-26 03:49:55 ERROR [th:140695601846080] (host.py:403): virsh net-update default delete ip-dhcp-range "<range start='192.168.122.2' end='192.168.122.254' />" --live --config failed: error: Failed to update network default
  error: Requested operation is not valid: couldn't locate a matching dhcp range entry in network 'default'
```
Fixes: 016101de82b3 ('Avoid deleting/recreating bridge when not needed.')