### PR TITLE
[th/rangelist-cleanup] common: fixes for RangeList and make it immutable

### DIFF
--- a/clustersConfig.py
+++ b/clustersConfig.py
@@ -169,7 +169,11 @@ class ClustersConfig:
     # Used to warn the user to change their config.
     deprecated_configs: dict[str, Optional[str]] = {"api_ip": "api_vip", "ingress_ip": "ingress_vip"}
 
-    def __init__(self, yaml_path: str, worker_range: common.RangeList):
+    def __init__(
+        self,
+        yaml_path: str,
+        worker_range: common.RangeList = common.RangeList.UNLIMITED,
+    ):
         self._cluster_info: Optional[ClusterInfo] = None
         self._load_full_config(yaml_path)
         self._check_deprecated_config()
@@ -204,7 +208,7 @@ class ClustersConfig:
             self.masters.append(NodeConfig(self.name, **n))
 
         self.configured_workers = [NodeConfig(self.name, **w) for w in cc["workers"]]
-        self.workers = [NodeConfig(self.name, **w) for w in worker_range.filter_list(cc["workers"])]
+        self.workers = [NodeConfig(self.name, **w) for w in worker_range.filter(cc["workers"])]
 
         if self.kind == "openshift":
             self.configure_ip_range()

--- a/isoCluster.py
+++ b/isoCluster.py
@@ -103,7 +103,7 @@ def enable_acc_connectivity(node: NodeConfig) -> None:
     ipu_acc.ping()
     ipu_acc.ssh_connect("root", "redhat")
     ipu_acc.run("nmcli con mod enp0s1f0 ipv4.route-metric 0")
-    ipu_acc.run("ip route delete default via 192.168.0.1") # remove imc default route to avoid conflict
+    ipu_acc.run("ip route delete default via 192.168.0.1")  # remove imc default route to avoid conflict
     logger.info(f"{node.name} connectivity established")
 
 


### PR DESCRIPTION
- `RangeList._range` was previously a class variable. That's wrong, it
  should be per instance.

- make `RangeList` immutable and drop the `include()`/`exclude()` methods.
  Pass all parameters at construct time.

- no longer have this odd split between `RangeList.initial_values` and
  `RangeList._range`. Instead, there is a set of includes and a set of
  excludes.

- accept ranges as strings as parameters for include/exclude arguments.

- add `RangeList.UNLIMITED` singleton. It's the default for the
  `ClustersConfig()` constructor.

- handle multiple `'-w"`/`"-sw" options on the command line.
