### PR TITLE
[th/github-pip-requirements] github: install pip packages from "requirements.txt" in test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install --upgrade setuptools wheel
+        python -m pip install --upgrade setuptools
+        python -m pip install --upgrade wheel
         python -m pip install black==22.12.0
         python -m pip install flake8
         python -m pip install flake8-comprehensions
@@ -30,10 +31,9 @@ jobs:
         python -m pip install types-PyYAML
         python -m pip install types-requests
         python -m pip install pytest
-        python -m pip install aicli
         python -m pip install paramiko==2.12.0
         python -m pip install gitpython
-        python -m pip install kubernetes
+        python -m pip install -r requirements.txt
     - name: black
       run: |
         black --version


### PR DESCRIPTION
he packages from requirements.txt may or may not be necessary for
running out tests. However:

- tomorrow we add a test that requires a package from
  "requirements.txt", then we constantly need to keep the second
  list of installed packages.

- for the test, even if they currently don't test all packages
  from "requirements.txt", we want at least see that those are
  installable. Install them.
