### PR TITLE
[th/fix-secrets-path] cda: fix passing secrets_path to ClustersConfig

### DIFF
--- a/cda.py
+++ b/cda.py
@@ -51,7 +51,11 @@ def main_deploy_iso(cc: ClustersConfig, args: argparse.Namespace) -> None:
 
 
 def main_deploy(args: argparse.Namespace) -> None:
-    cc = ClustersConfig(args.config, args.secrets_path, args.worker_range)
+    cc = ClustersConfig(
+        args.config,
+        secrets_path=args.secrets_path,
+        worker_range=args.worker_range,
+    )
 
     if cc.kind == "openshift":
         main_deploy_openshift(cc, args)
@@ -61,7 +65,10 @@ def main_deploy(args: argparse.Namespace) -> None:
 
 def main_snapshot(args: argparse.Namespace) -> None:
     args = parse_args()
-    cc = ClustersConfig(args.config, args.worker_range)
+    cc = ClustersConfig(
+        args.config,
+        worker_range=args.worker_range,
+    )
 
     ais = AssistedInstallerService(cc.version, args.url)
     ai = AssistedClientAutomation(f"{args.url}:8090")

--- a/clustersConfig.py
+++ b/clustersConfig.py
@@ -170,7 +170,13 @@ class ClustersConfig:
     # Used to warn the user to change their config.
     deprecated_configs: dict[str, Optional[str]] = {"api_ip": "api_vip", "ingress_ip": "ingress_vip"}
 
-    def __init__(self, yaml_path: str, secrets_path: str, worker_range: common.RangeList = common.RangeList.UNLIMITED):
+    def __init__(
+        self,
+        yaml_path: str,
+        *,
+        secrets_path: str = "",
+        worker_range: common.RangeList = common.RangeList.UNLIMITED,
+    ):
         self._cluster_info: Optional[ClusterInfo] = None
         self._load_full_config(yaml_path)
         self._check_deprecated_config()


### PR DESCRIPTION
"secrets_path" was a mandatory positional argument. "main_snapshot()" missed to pass that argument on. Fix that.

While at it, make the parameter a kw_only argument so that such an error not possible. Also, add a default value, since main_snapshot() doesn't have a value to set.

Fixes: ad13ce19afd2 ('Propagate secret settings')