### PR TITLE
clustersConfig: update autodetect for base url

### DIFF
--- a/clusterInfo.py
+++ b/clusterInfo.py
@@ -10,7 +10,7 @@ class ClusterInfo:
         self.name = name
         self.provision_host = ""
         self.network_api_port = ""
-        self.iso = ""
+        self.iso_server = ""
         self.organization_id = ""
         self.activation_key = ""
         self.bmc_imc_hostnames = []  # type: list[str]
@@ -53,7 +53,7 @@ def load_all_cluster_info() -> dict[str, ClusterInfo]:
         if row["Card type"] == "IPU-Cluster":
             cluster.bmc_imc_hostnames.append(row["BMC/IMC hostname"])
             cluster.ipu_mac_addresses.append(row["MAC"])
-            cluster.iso = row["Install ISO"]
+            cluster.iso_server = row["ISO server"]
             cluster.activation_key = row["Activation Key"]
             cluster.organization_id = row["Organization ID"]
         if row["Provision host"] == "yes":

--- a/clustersConfig.py
+++ b/clustersConfig.py
@@ -384,10 +384,10 @@ class ClustersConfig:
             assert self._cluster_info is not None
             return self._cluster_info.network_api_port
 
-        def iso() -> str:
+        def iso_server() -> str:
             self._ensure_clusters_loaded()
             assert self._cluster_info is not None
-            return self._cluster_info.iso
+            return self._cluster_info.iso_server
 
         def activation_key() -> str:
             self._ensure_clusters_loaded()
@@ -415,7 +415,7 @@ class ClustersConfig:
         template.globals['worker_number'] = worker_number
         template.globals['worker_name'] = worker_name
         template.globals['api_network'] = api_network
-        template.globals['iso'] = iso
+        template.globals['iso_server'] = iso_server
         template.globals['bmc'] = bmc
         template.globals['activation_key'] = activation_key
         template.globals['organization_id'] = organization_id


### PR DESCRIPTION
Rather than detecting the full path to the iso, only detect the base url. The iso file itself will be provided by the user of CDA instead.

Update naming accordingly