### PR TITLE
[th/cluster-deployer-is-bf] clusterDeployer: fix is-bf check in ClusterDeployer

### DIFF
--- a/clusterDeployer.py
+++ b/clusterDeployer.py
@@ -77,9 +77,10 @@ class ClusterDeployer(BaseDeployer):
         self._all_nodes = {k8s_node.config.name: k8s_node for h in self._all_hosts for k8s_node in h._k8s_nodes()}
 
         self.masters_arch = "x86_64"
-        self.is_bf = (x.kind == "bf" for x in self._cc.workers)
-        if any(self.is_bf):
-            if not all(self.is_bf):
+        is_bf_map = [x.kind == "bf" for x in self._cc.workers]
+        self.is_bf = any(is_bf_map)
+        if self.is_bf:
+            if not all(is_bf_map):
                 logger.error_and_exit("Not yet supported to have mixed BF and non-bf workers")
             self.workers_arch = "arm64"
         else:


### PR DESCRIPTION
`self.is_bf` was assigned a generator. The later check `if not self.is_bf:` would never evaluate to true and `iso_path = os.getcwd()` was never executed.

Fix that. Note that this changes (fixes?) behavior for the common case, where we don't have "bf" nodes.

Also, a generator can only be iterated once, hence the `if not all(self.is_bf):` check also never hit. But that was not very important, because that was only a consistency check of the configuration.