### PR TITLE
[th/fix-microshift-deploy] clusterDeployer: fix passing secret_path to microshift.deploy()

### DIFF
--- a/clusterDeployer.py
+++ b/clusterDeployer.py
@@ -230,7 +230,12 @@ class ClusterDeployer(BaseDeployer):
             version = match_to_proper_version_format(self._cc.version)
 
             if len(self._cc.masters) == 1:
-                microshift.deploy(self._cc.fullConfig["name"], self._cc.masters[0], self._cc.external_port, version)
+                microshift.deploy(
+                    secrets_path=self._secrets_path,
+                    node=self._cc.masters[0],
+                    external_port=self._cc.external_port,
+                    version=version,
+                )
             else:
                 logger.error_and_exit("Masters must be of length one for deploying microshift")
         if POST_STEP in self.steps:

--- a/microshift.py
+++ b/microshift.py
@@ -216,7 +216,13 @@ rhsm = true'''.strip()
     shutil.rmtree("/var/cache/osbuild-worker/osbuild-store/stage/")
 
 
-def deploy(secrets_path: str, node: NodeConfig, external_port: str, version: str) -> None:
+def deploy(
+    *,
+    secrets_path: str,
+    node: NodeConfig,
+    external_port: str,
+    version: str,
+) -> None:
     lh = host.LocalHost()
     bmc = BMC.from_bmc(node.bmc, node.bmc_user, node.bmc_password)
     h = Host(node.node, bmc)


### PR DESCRIPTION
Also, switch to use keyword arguments (and force using kw args on microshift.deploy()) to avoid such errors in the future.

Fixes: ad13ce19afd2 ('Propagate secret settings')