### PR TITLE
[th/host-no-log] host: don't log message from Host() constructor

### DIFF
--- a/host.py
+++ b/host.py
@@ -215,7 +215,6 @@ class Host:
         key = (hostname, bmc.url if bmc else None)
         if key not in host_instances:
             host_instances[key] = super().__new__(cls)
-            logger.debug(f"new instance for {hostname}")
         return host_instances[key]
 
     def __init__(self, hostname: str, bmc: Optional[BMC] = None):


### PR DESCRIPTION
`K8sClient.__init__()` has a default argument with
```
  host: host.Host = host.LocalHost()
```
That means, importing "k8sClient.py" will instantiate a Host instance. Note that this can easily happen. For example, while parsing the YAML in "clustersConfig.py" we may import some other modules (for example, to validate the `ExtraConfigArgs`). Those modules in turn can include `k8sClient` module.

Merely importing the module already spams the log. That seems wrong. Even if this is "only" at debug level, the debug level is enabled by default, unless you set another level (which "cda.py" does, but each tool would have to do that, and it would have to do so before importing `k8sClient` module).

Maybe default values should be trivial, and we should have `host:Optional[host.Host]=None`. But rather, here it seems that logging this message is just too noisy.

Also, we internalize the host instances. Hence, for most cases we won't see this message when a user seemingly creates a new Host. Instead, we end up re-using an existing one and no line is logged.