### PR TITLE
[th/git-repo-setup] don't use "/root/dpu-operator" as default path and don't set a default branch (instead, honor HEAD)

### DIFF
--- a/clustersConfig.py
+++ b/clustersConfig.py
@@ -54,7 +54,7 @@ class ExtraConfigArgs:
 
     activation_key: Optional[str] = None
 
-    dpu_operator_path: Optional[str] = "/root/dpu-operator"
+    dpu_operator_path: str = "/root/dpu-operator"
 
     rebuild_dpu_operators_images: bool = True
 

--- a/common.py
+++ b/common.py
@@ -588,7 +588,7 @@ def build_sriov_network_operator_check_permissions() -> bool:
     return ret.success()
 
 
-def git_repo_setup(repo_dir: str, *, repo_wipe: bool = True, url: str, branch: Optional[str] = "master") -> None:
+def git_repo_setup(repo_dir: str, *, repo_wipe: bool = True, url: str, branch: Optional[str] = None) -> None:
     exists = os.path.exists(repo_dir)
     if exists and not repo_wipe:
         return

--- a/common.py
+++ b/common.py
@@ -588,14 +588,10 @@ def build_sriov_network_operator_check_permissions() -> bool:
     return ret.success()
 
 
-def git_repo_setup(repo_dir: Optional[str] = "/root/dpu-operator", *, repo_wipe: bool = True, url: str, branch: Optional[str] = "master") -> None:
-    if repo_dir is None:
-        raise ValueError("repo_dir cannot be None")
-
+def git_repo_setup(repo_dir: str, *, repo_wipe: bool = True, url: str, branch: Optional[str] = "master") -> None:
     exists = os.path.exists(repo_dir)
     if exists and not repo_wipe:
         return
-
     if exists:
         shutil.rmtree(repo_dir)
 

--- a/extraConfigDpu.py
+++ b/extraConfigDpu.py
@@ -15,7 +15,6 @@ from imageRegistry import ImageRegistry
 DPU_OPERATOR_REPO = "https://github.com/openshift/dpu-operator.git"
 MICROSHIFT_KUBECONFIG = "/root/kubeconfig.microshift"
 OSE_DOCKERFILE = "https://pkgs.devel.redhat.com/cgit/containers/dpu-operator/tree/Dockerfile?h=rhaos-4.17-rhel-9"
-REPO_DIR = "/root/dpu-operator"
 
 KERNEL_RPMS = [
     "https://download-01.beak-001.prod.iad2.dc.redhat.com/brewroot/vol/rhel-9/packages/kernel/5.14.0/427.2.1.el9_4/x86_64/kernel-5.14.0-427.2.1.el9_4.x86_64.rpm",


### PR DESCRIPTION
- common: don't have default "repo_dir" in common.git_repo_setup()
- common: change default "branch" for common.git_repo_setup()
