### PR TITLE
[th/cluster-node-strict-types] use __slots__ in ClusterNode,ClusterHost for more typing help

### DIFF
--- a/clusterHost.py
+++ b/clusterHost.py
@@ -26,15 +26,27 @@ class ClusterHost:
     bridge: VirBridge
     config: HostConfig
     needs_api_network: bool
-    api_port: Optional[str] = None
+    api_port: Optional[str]
     k8s_master_nodes: list[ClusterNode]
     k8s_worker_nodes: list[ClusterNode]
     hosts_vms: bool
+
+    __slots__ = [
+        "hostconn",
+        "bridge",
+        "config",
+        "needs_api_network",
+        "api_port",
+        "k8s_master_nodes",
+        "k8s_worker_nodes",
+        "hosts_vms",
+    ]
 
     def __init__(self, h: host.Host, c: HostConfig, cc: ClustersConfig, bc: BridgeConfig):
         self.bridge = VirBridge(h, bc)
         self.hostconn = h
         self.config = c
+        self.api_port = None
 
         def _create_k8s_nodes(configs: list[NodeConfig]) -> list[ClusterNode]:
             nodes: list[ClusterNode] = []

--- a/clusterNode.py
+++ b/clusterNode.py
@@ -117,10 +117,6 @@ class VmClusterNode(ClusterNode):
         self.hostconn = h
         self.install_wait = True
 
-    def ip(self) -> str:
-        assert self.config.ip is not None
-        return self.config.ip
-
     def setup_vm(self, iso_or_image_path: str) -> host.Result:
         disk_size_gb = self.config.disk_size
         if iso_or_image_path.endswith(".iso"):

--- a/clusterNode.py
+++ b/clusterNode.py
@@ -27,11 +27,18 @@ class ClusterNode:
 
     config: NodeConfig
     future: Future[Optional[host.Result]]
-    dynamic_ip: Optional[str] = None
+    dynamic_ip: Optional[str]
+
+    __slots__ = [
+        "config",
+        "future",
+        "dynamic_ip",
+    ]
 
     def __init__(self, config: NodeConfig):
         self.config = config
         self.future = common.empty_future(host.Result)
+        self.dynamic_ip = None
 
     def ip(self) -> str:
         if self.config.ip is not None:
@@ -98,11 +105,17 @@ class ClusterNode:
 
 class VmClusterNode(ClusterNode):
     hostconn: host.Host
-    install_wait: bool = True
+    install_wait: bool
+
+    __slots__ = [
+        "hostconn",
+        "install_wait",
+    ]
 
     def __init__(self, h: host.Host, config: NodeConfig):
         super().__init__(config)
         self.hostconn = h
+        self.install_wait = True
 
     def ip(self) -> str:
         assert self.config.ip is not None
@@ -192,6 +205,10 @@ class VmClusterNode(ClusterNode):
 class X86ClusterNode(ClusterNode):
     external_port: str
 
+    __slots__ = [
+        "external_port",
+    ]
+
     def __init__(self, config: NodeConfig, external_port: str):
         super().__init__(config)
         self.external_port = external_port
@@ -237,6 +254,10 @@ class X86ClusterNode(ClusterNode):
 
 class BFClusterNode(ClusterNode):
     external_port: str
+
+    __slots__ = [
+        "external_port",
+    ]
 
     def __init__(self, config: NodeConfig, external_port: str):
         super().__init__(config)


### PR DESCRIPTION
With `__slots__`, mypy knows the valid fields of an object.

The classes are confusing enough, it's useful to see exactly which fields exist and tighten up the checks. This helps by letting the linter confirm that only those attributes exists.


Also, drop the unnecessary `VmClusterNode.ip()` function.