### PR TITLE
Update vsp naming

### DIFF
--- a/dpuVendor.py
+++ b/dpuVendor.py
@@ -49,7 +49,7 @@ class IpuPlugin(VendorPlugin):
         lh.run(f"podman push intel-ipuplugin:latest {self.vsp_image_name(img_reg)}")
 
     def vsp_image_name(self, img_reg: ImageRegistry) -> str:
-        return f"{img_reg.url()}/ipu-plugin:dpu-{self.name_suffix}"
+        return f"{img_reg.url()}/intel_vsp:dev"
 
     def build_push_start(self, h: host.Host, client: K8sClient, imgReg: ImageRegistry) -> None:
         return self.start(self.build_push(h, imgReg), client)

--- a/extraConfigDpu.py
+++ b/extraConfigDpu.py
@@ -180,10 +180,10 @@ def ExtraConfigDpu(cc: ClustersConfig, cfg: ExtraConfigArgs, futures: dict[str, 
         # (the Dockerfile needs to be fixed to allow layered multi-arch build
         # by removing the calls to pip)
         vendor_plugin.build_push(acc, imgReg)
-        vendor_plugin.start(vendor_plugin.vsp_image_name(imgReg), client)
+        # vendor_plugin.start(vendor_plugin.vsp_image_name(imgReg), client)
     else:
         vendor_plugin.build_push_start(lh, client, imgReg)
-    wait_vsp_ds_running(client)
+        wait_vsp_ds_running(client)
 
     git_repo_setup(repo, repo_wipe=False, url=DPU_OPERATOR_REPO)
     if cfg.rebuild_dpu_operators_images:
@@ -230,8 +230,11 @@ def ExtraConfigDpuHost(cc: ClustersConfig, cfg: ExtraConfigArgs, futures: dict[s
     h = host.Host(node.node)
     h.ssh_connect("core")
     vendor_plugin = init_vendor_plugin(h, node.kind or "")
-    vendor_plugin.build_push_start(lh, client, imgReg)
-    wait_vsp_ds_running(client)
+    if isinstance(vendor_plugin, IpuPlugin):
+        vendor_plugin.build_push(lh, imgReg)
+    else:
+        vendor_plugin.build_push_start(lh, client, imgReg)
+        wait_vsp_ds_running(client)
 
     git_repo_setup(repo, branch="main", repo_wipe=False, url=DPU_OPERATOR_REPO)
     if cfg.rebuild_dpu_operators_images:


### PR DESCRIPTION
With the changes in https://github.com/openshift/dpu-operator/pull/128
we not longer need to start the vsp, this will be handled by the dpu
operator.

We will not remove the "Start" functionality, since the option to deploy
the vsp manually outside the dpu operator is maintained / will be
required for non-Intel vsps.

Update the vsp naming so that it can be properly deployed by
https://github.com/openshift/dpu-operator/pull/128.

TODO: We should add multiarch support via buildah to ipu plugins so that
we can pull a single manifest rather than needing to build and tag
multiple images individually.