### PR TITLE
Buildah manifest

### DIFF
--- a/dpuVendor.py
+++ b/dpuVendor.py
@@ -72,6 +72,11 @@ class IpuPlugin(VendorPlugin):
         vsp_image = self.vsp_image_name(imgReg)
         h.run_or_die(f"podman tag intel-ipuplugin:latest {vsp_image}")
         h.run_or_die(f"podman push {vsp_image}")
+        # WA to ensure multiarch vsp image manifest is available
+        # push images with both the name expected by the dpu operator (so we can proceed with deploying host side)
+        # and the name expected by the manifest that we will build during the IPU deployment step
+        h.run_or_die(f"podman tag {vsp_image} {vsp_image}-{self.name_suffix}")
+        h.run_or_die(f"podman push {vsp_image}-{self.name_suffix}")
         return vsp_image
 
     def start(self, vsp_image: str, client: K8sClient) -> None:

--- a/extraConfigDpu.py
+++ b/extraConfigDpu.py
@@ -197,21 +197,7 @@ def ExtraConfigDpu(cc: ClustersConfig, cfg: ExtraConfigArgs, futures: dict[str, 
     logger.info("Waiting for all pods to become ready")
     client.oc_run_or_die("wait --for=condition=Ready pod --all --all-namespaces --timeout=2m")
     client.oc_run_or_die(f"create -f {repo}/examples/dpu.yaml")
-    time.sleep(30)
-
-    # TODO: remove wa once fixed in future versions of MeV
-    # Wait for dpu to restart after vsp triggers reboot
-    # Note, this will fail if the acc comes up with a new MAC address on the physical port.
-    # As a temporary workaround until this issue is resolved, pre-load the rh_mvp.pkg / configure the iscsi attempt
-    # to ensure the MAC remains consistent across reboots
-    acc.ssh_connect("root", "redhat")
-    if isinstance(vendor_plugin, IpuPlugin):
-        uname = acc.run("uname -r").out.strip()
-        cmd = f"podman run --network host -d --privileged --entrypoint='[\"/bin/sh\", \"-c\", \"sleep 5; sh /entrypoint.sh\"]' -v /lib/modules/{uname}:/lib/modules/{uname} -v data1:/opt/p4 {img}"
-        logger.info("Manually restarting P4 container")
-        acc.run_or_die(cmd)
-    acc.run_or_die("systemctl restart microshift")
-    client.oc_run_or_die("wait --for=condition=Ready pod --all --all-namespaces --timeout=2m")
+    client.oc_run_or_die("wait --for=condition=Ready pod --all --all-namespaces --timeout=3m")
     logger.info("Finished setting up dpu operator on dpu")
 
 

--- a/extraConfigDpu.py
+++ b/extraConfigDpu.py
@@ -181,9 +181,6 @@ def ExtraConfigDpu(cc: ClustersConfig, cfg: ExtraConfigArgs, futures: dict[str, 
         # by removing the calls to pip)
         vendor_plugin.build_push(acc, imgReg)
         # vendor_plugin.start(vendor_plugin.vsp_image_name(imgReg), client)
-    else:
-        vendor_plugin.build_push_start(lh, client, imgReg)
-        wait_vsp_ds_running(client)
 
     git_repo_setup(repo, repo_wipe=False, url=DPU_OPERATOR_REPO)
     if cfg.rebuild_dpu_operators_images:
@@ -218,9 +215,6 @@ def ExtraConfigDpuHost(cc: ClustersConfig, cfg: ExtraConfigArgs, futures: dict[s
     vendor_plugin = init_vendor_plugin(h, node.kind or "")
     if isinstance(vendor_plugin, IpuPlugin):
         vendor_plugin.build_push(lh, imgReg)
-    else:
-        vendor_plugin.build_push_start(lh, client, imgReg)
-        wait_vsp_ds_running(client)
 
     git_repo_setup(repo, branch="main", repo_wipe=False, url=DPU_OPERATOR_REPO)
     if cfg.rebuild_dpu_operators_images:


### PR DESCRIPTION
    dpuVendor: Build a multiarch ipu manifest
    
    The dpu-operator by default expects a multiarch vsp image.
    
    In the past, this code just worked, because we would build and push the
    image immediately before deploying the operator on the respective
    architecture, so the most recent image would be the proper arch.
    
    This is flimsy, and can cause errors later on if we need to pull the
    image again. Instead, as a workaround while waiting for multiarch IPU
    vsp build support, build a manifest of the images during the second
    phase of deployment (iso-cluster dpu).
    
    This code makes a (potentially bad) assumption that the host side
    deployment has already run, and built/pushed the x86_64 vsp.
    
    
depended on by: [1] https://github.com/openshift/dpu-operator/pull/168