### PR TITLE
bmc: fix cyclic dependency between "bmc" and "host" modules

### DIFF
--- a/host.py
+++ b/host.py
@@ -9,7 +9,7 @@ import shutil
 import sys
 import logging
 import tempfile
-from bmc import BMC
+import typing
 from typing import Optional
 from typing import Union
 from functools import lru_cache
@@ -115,13 +115,13 @@ class AutoLogin(Login):
 
 
 class Host:
-    def __new__(cls, hostname: str, bmc: Optional[BMC] = None) -> 'Host':
+    def __new__(cls, hostname: str, bmc: Optional["BMC"] = None) -> 'Host':
         key = (hostname, bmc.url if bmc else None)
         if key not in host_instances:
             host_instances[key] = super().__new__(cls)
         return host_instances[key]
 
-    def __init__(self, hostname: str, bmc: Optional[BMC] = None):
+    def __init__(self, hostname: str, bmc: Optional["BMC"] = None):
         self._hostname = hostname
         self._bmc = bmc
         self._logins: list[Login] = []
@@ -519,3 +519,7 @@ def LocalHost() -> Host:
 
 def RemoteHost(ip: str) -> Host:
     return Host(ip)
+
+
+if typing.TYPE_CHECKING:
+    from bmc import BMC


### PR DESCRIPTION
```
  $ python -c 'import bmc'
  Traceback (most recent call last):
    File "<string>", line 1, in <module>
    File "./cluster-deployment-automation/bmc.py", line 7, in <module>
      import host
    File "./cluster-deployment-automation/host.py", line 12, in <module>
      from bmc import BMC
  ImportError: cannot import name 'BMC' from partially initialized module 'bmc' (most likely due to a circular import) (./cluster-deployment-automation/bmc.py)
```