### PR TITLE
Proper vsp testing

### DIFF
--- a/clustersConfig.py
+++ b/clustersConfig.py
@@ -56,6 +56,9 @@ class ExtraConfigArgs:
 
     dpu_operator_path: str = "/root/dpu-operator"
 
+    # Specify the commit to checkout when building https://github.com/intel/ipu-opi-plugins
+    ipu_plugin_sha: str = "main"
+
     rebuild_dpu_operators_images: bool = True
 
     dpu_net_interface: Optional[str] = "ens2f0"

--- a/dpuVendor.py
+++ b/dpuVendor.py
@@ -52,15 +52,15 @@ class IpuPlugin(VendorPlugin):
         return f"{img_reg.url()}/intel_vsp:dev"
 
     def build_push_start(self, h: host.Host, client: K8sClient, imgReg: ImageRegistry) -> None:
-        return self.start(self.build_push(h, imgReg), client)
+        return self.start(self.build_push(h, imgReg, "main"), client)
 
-    def build_push(self, h: host.Host, imgReg: ImageRegistry) -> str:
+    def build_push(self, h: host.Host, imgReg: ImageRegistry, sha: str) -> str:
         logger.info("Building ipu-opi-plugin")
         h.run("rm -rf /root/ipu-opi-plugins")
         h.run_or_die(f"git clone {self.repo} /root/ipu-opi-plugins")
 
-        # WA until 1.8 VSP has been merged / validated into main branch
-        # h.run_or_die("git -C /root/ipu-opi-plugins checkout 1.6.2_MEV_REL_new_artifacts")
+        logger.info(f"Will build ipu-opi-plugin from commit f{sha}")
+        h.run_or_die(f"git checkout {sha}")
 
         fn = "/root/ipu-opi-plugins/ipu-plugin/images/Dockerfile"
         golang_img = extractContainerImage(h.read_file(fn))

--- a/extraConfigDpu.py
+++ b/extraConfigDpu.py
@@ -194,7 +194,7 @@ def ExtraConfigDpu(cc: ClustersConfig, cfg: ExtraConfigArgs, futures: dict[str, 
         # Build on the ACC since an aarch based server is needed for the build
         # (the Dockerfile needs to be fixed to allow layered multi-arch build
         # by removing the calls to pip)
-        vsp_img = vendor_plugin.build_push(acc, imgReg)
+        vsp_img = vendor_plugin.build_push(acc, imgReg, cfg.ipu_plugin_sha)
 
         # As a workaround while waiting for properly multiarch build support, we can create a manifest to ensure both host and dpu can deploy the vsp with the same image.
         # Note that this makes the assumption that the host deployment has already been run and the latest ipu plugin image is already locally available in the registry.
@@ -241,7 +241,7 @@ def ExtraConfigDpuHost(cc: ClustersConfig, cfg: ExtraConfigArgs, futures: dict[s
     h.ssh_connect("core")
     vendor_plugin = init_vendor_plugin(h, node.kind or "")
     if isinstance(vendor_plugin, IpuPlugin):
-        vendor_plugin.build_push(lh, imgReg)
+        vendor_plugin.build_push(lh, imgReg, cfg.ipu_plugin_sha)
 
     git_repo_setup(repo, branch="main", repo_wipe=False, url=DPU_OPERATOR_REPO)
     if cfg.rebuild_dpu_operators_images:

--- a/extraConfigDpu.py
+++ b/extraConfigDpu.py
@@ -251,26 +251,6 @@ def ExtraConfigDpuHost(cc: ClustersConfig, cfg: ExtraConfigArgs, futures: dict[s
     dpu_operator_start(client, repo)
 
     def helper(h: host.Host, node: NodeConfig) -> Optional[host.Result]:
-        # Temporary workaround, remove once 4.16 installations are working
-        logger.info("Ensuring Rhel 9.4 kernel is installed")
-        ensure_rhel_9_4_kernel_is_installed(h)
-        # There is a bug with the idpf driver that causes the IPU to fail to be enumerated over PCIe on boot
-        # As a result, we will need to trigger cold boots of the node until the device is available
-        # TODO: Remove when no longer needed
-        retries = 3
-        h.ssh_connect("core")
-        ret = h.run(f"test -d /sys/class/net/{cfg.dpu_net_interface}")
-        while ret.returncode != 0:
-            logger.error(f"{h.hostname()} does not have a network device {cfg.dpu_net_interface} cold booting node to try to recover")
-            h.cold_boot()
-            logger.info("Cold boot triggered, waiting for host to reboot")
-            time.sleep(60)
-            h.ssh_connect("core")
-            retries = retries - 1
-            if retries == 0:
-                logger.error_and_exit(f"Failed to bring up IPU net device on {h.hostname()}")
-            ret = h.run(f"test -d /sys/class/net/{cfg.dpu_net_interface}")
-
         # Label the node
         logger.info(f"labeling node {h.hostname()} dpu=true")
         client.oc_run_or_die(f"label no {e.name} dpu=true")


### PR DESCRIPTION
dpuVendor: Specify Intel vsp commit to build from:
Since we do not yet have the Intel VSP tracked in the dpu operator, we
should add this field to the config file.

This way, changes to the vsp must be passed in the dpu operator CI
before we bump our tests to pull these in


extraConfigDpu: remove idpf netdev restart:
In theory we should no longer need to manually cold boot the servers to
ensure idpf netdevs are available.

Currently there is a bug in MeV 1.8 that causes the host to reboot any
time the IMC reboots, which masks this issue from occurring.

If this masking is removed, we want to see failure here to signify that
lifecycle management of the IPU is broken