### PR TITLE
AssistedInstaller: pin AI pods to speed up deploy

### DIFF
--- a/assistedInstallerService.py
+++ b/assistedInstallerService.py
@@ -50,10 +50,10 @@ class AssistedInstallerService:
     # The values are taken from:
     # https://gitlab.cee.redhat.com/service/app-interface/-/blob/ee5f631ce539537085b5ef043bbd9593fa74f860/data/services/assisted-installer/cicd/target/production/assisted-service.yaml#L44-47
     #
-    SAAS_VERSION = "latest"
-    INSTALLER_IMAGE = "registry.redhat.io/rhai-tech-preview/assisted-installer-rhel8:v1.0.0-347"
-    CONTROLLER_IMAGE = "registry.redhat.io/rhai-tech-preview/assisted-installer-reporter-rhel8:v1.0.0-425"
-    AGENT_DOCKER_IMAGE = "registry.redhat.io/rhai-tech-preview/assisted-installer-agent-rhel8:v1.0.0-328"
+    SAAS_VERSION = "v2.31.6"
+    INSTALLER_IMAGE = "registry.redhat.io/rhai-tech-preview/assisted-installer-rhel8:v1.0.0-340"
+    CONTROLLER_IMAGE = "registry.redhat.io/rhai-tech-preview/assisted-installer-reporter-rhel8:v1.0.0-418"
+    AGENT_DOCKER_IMAGE = "registry.redhat.io/rhai-tech-preview/assisted-installer-agent-rhel8:v1.0.0-315"
 
     def __init__(self, version: str, ip: str, proxy: Optional[str] = None, noproxy: Optional[str] = None, branch: str = "master"):
         self._version = version


### PR DESCRIPTION
Some change to assisted installer causes it to increase from ~15 to ~1hour after starting a cluster for the cluster to reach state installing.

As a temporary workaround, we can pin the pods to before this change was introduced.