### PR TITLE
[th/mypy-config] mypy: set "strict" and "files" and move config to "pyproject.toml"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
     - name: mypy
       run: |
         mypy --version
-        mypy --strict --config-file mypy.ini .
+        mypy
     - name: pytest
       # Tests may want to know whether they run under CI in github actions.
       #

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,3 +1,0 @@
-[mypy]
-ignore_missing_imports = True
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,3 +2,7 @@
 line-length = 250
 skip-string-normalization = 1
 
+[tool.mypy]
+ignore_missing_imports = true
+strict = true
+files = "."


### PR DESCRIPTION
- move "mypy.ini" to "pyproject.toml". That is an alternative, valid location for mypy configuration. This way we have fewer files around.

- set `strict = true` and `files = "."`. The benefit is that this is how we want to run mypy. By setting these options in the configuration file, we no longer need to specify them on the `mypy` command line.