### PR TITLE
[th/ktoolbox] ktoolbox: include "ktoolbox" package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ kubernetes
 python-hosts
 argcomplete
 yq
+git+https://github.com/thom311/ktoolbox@3159f67841efc1ee5b7d82c1173218326f3ef380


### PR DESCRIPTION
This is a re-opening of https://github.com/bn222/cluster-deployment-automation/pull/273

---

This contains general purpose utilities that we have control over (written by us).

We have multiple python projects, and there is a use in sharing code between them. We could instead have a mono-repo, or we could copy and paste around code, or we could reimplement things (differently). Instead, "ktoolbox" is the place where python code can be shared.

Currently "ktoolbox" does not guarantee a stable API. So you best refer to a specifiy commit.

[1] https://github.com/thom311/ktoolbox
