### PR TITLE
[th/dpu-operator-default-images] Use default "{builder,base}_image" from dpu-operator's Dockerfiles

### DIFF
--- a/clustersConfig.py
+++ b/clustersConfig.py
@@ -64,9 +64,9 @@ class ExtraConfigArgs:
 
     dpu_net_interface: Optional[str] = "ens2f0"
 
-    builder_image: str = "wsfd-advnetlab-amp04.anl.eng.bos2.dc.redhat.com:5000/ocp/builder:rhel-9-golang-1.22-openshift-4.18"
+    builder_image: str = ""
 
-    base_image: str = "wsfd-advnetlab-amp04.anl.eng.bos2.dc.redhat.com:5000/ocp/4.18:base-rhel9"
+    base_image: str = ""
 
     def pre_check(self) -> None:
         if self.sriov_network_operator_local:


### PR DESCRIPTION
Note that dpu-operator, a main user of the "dpu_operator_{host,dpu}" postconfig, already explicitly sets images ([1]). Apparently, the defaults set in CDA are deemed insufficient.

Also note that those default images are hosted inside Red Hat infrastructure, so they only work for certain users. That means, external users will have to provide their own images.

Also, using those images use self-signed certificates and currently requires the user to install a certificate (optimally, CDA would support passing "--tls-verify=false", for which there are patches that might be posted later).

Anyway. This doesn't seem a good default. By default the user should get the images in the dpu-operator's Dockerfiles. Change the default to being unset, which has the effect of leaving the images alone.

Note that the default images in dpu-operator's Dockerfiles are from registry.ci.openshift.org, so they require some Red Hat authentication too and may not be usable to everybody either. But that is a decision of dpu-operator, and not something that CDA should overwrite with some other defaults that have a different set of problems.

[1] https://github.com/openshift/dpu-operator/commit/961136a61576df8f12fe715dd50b923b5f1e473b