### PR TITLE
[th/marvell-tools-install-kernel] isoCluster: pass "--default-extra-packages" to marvell-tools' "pxeboot.py"

### DIFF
--- a/isoCluster.py
+++ b/isoCluster.py
@@ -46,6 +46,7 @@ def _pxeboot_marvell_dpu(name: str, node: str, mac: str, ip: str, iso: str) -> N
         f"--nm-secondary-ip-address={shlex.quote(ip_addr)} "
         f"--nm-secondary-ip-gateway={shlex.quote(ip_gateway)} "
         "--yum-repos=rhel-nightly "
+        "--default-extra-packages "
         f"{' '.join(ssh_key_options)} "
         f"{shlex.quote(iso)} "
         "2>&1"


### PR DESCRIPTION
The current rhel-9 kernel lacks patches for the Marvell DPU (on the DPU side). This will be fixed eventually, but for now, we must install another kernel.

Marvell-tools has a command line argument to install RPMs of a suitable kernel.  Use it.

Note that the option is just called "--default-extra-packages". In the future, when the workaround is no longer necessary, then "marvell-tools" will decided that it no longer needs to install any extra packages.  In CDA, the option will always be passed to the pxeboot command.

If CDA always passes this option to pxeboot command, why does it even exist? Because the pxeboot command can be used without CDA, and because in that use case it's deemed better to not install the packages without being asked to.