### PR TITLE
clustersConfig: Do not recreate the NodeConfig

### DIFF
--- a/clustersConfig.py
+++ b/clustersConfig.py
@@ -233,7 +233,7 @@ class ClustersConfig:
             self.masters.append(NodeConfig(self.name, **n))
 
         self.configured_workers = [NodeConfig(self.name, **w) for w in cc["workers"]]
-        self.workers = [NodeConfig(self.name, **w) for w in worker_range.filter(cc["workers"])]
+        self.workers = list(worker_range.filter(self.configured_workers))
 
         self.set_cc_hosts_defaults(cc)
 


### PR DESCRIPTION
The NodeConfig is created once for each worker, that results in MAC being generated when it's not present. The list of workers that are specified by the batch (--workers/--skip--workers) is list of NodeConfigs too, however the second initialization would lead to MAC collisions as the second list would always collide between runs if the batch shifted.

Make sure the second NodeConfig is actually the same as original one so the MAC can stay consistent between batches.