### PR TITLE
[th/cluster-info-tool] make `clusterInfo.py` executable tool to fetch cluster info

### DIFF
--- a/clusterInfo.py
+++ b/clusterInfo.py
@@ -2,6 +2,8 @@ import dataclasses
 import os
 import gspread
 import tenacity
+from typing import Optional
+from collections.abc import Iterable
 from oauth2client.service_account import ServiceAccountCredentials
 from logger import logger
 
@@ -52,9 +54,17 @@ def _read_gspread_sheet_with_retry(cred_path: str) -> gspread.spreadsheet.Spread
     return _read_gspread_sheet(cred_path)
 
 
-def read_sheet() -> list[dict[str, str]]:
+def read_sheet(
+    *,
+    credentials: Optional[str | Iterable[str]] = None,
+) -> list[dict[str, str]]:
     logger.info(f"Reading cluster information from sheet {repr(SHEET)} ( {URL} )")
-    cred_paths = _default_cred_paths()
+    if credentials is None:
+        cred_paths = _default_cred_paths()
+    elif isinstance(credentials, str):
+        cred_paths = [credentials]
+    else:
+        cred_paths = list(credentials)
     cred_path = None
     for e in cred_paths:
         if os.path.exists(e):

--- a/clusterInfo.py
+++ b/clusterInfo.py
@@ -1,9 +1,12 @@
-import sys
 import os
 import gspread
 import tenacity
 from oauth2client.service_account import ServiceAccountCredentials
 from logger import logger
+
+
+SHEET = "ANL lab HW enablement clusters and connections"
+URL = "https://docs.google.com/spreadsheets/d/1lXvcodJ8dmc_hcp0hzbPDU8t6-hCnAlEWFRdM2r_n0Q"
 
 
 class ClusterInfo:
@@ -34,7 +37,7 @@ def _default_cred_paths() -> list[str]:
 
 @tenacity.retry(wait=tenacity.wait_fixed(10), stop=tenacity.stop_after_attempt(5))
 def read_sheet() -> list[dict[str, str]]:
-    logger.info("Downloading sheet from Google")
+    logger.info(f"Reading cluster information from sheet {repr(SHEET)} ( {URL} )")
     scopes = ['https://www.googleapis.com/auth/spreadsheets', 'https://www.googleapis.com/auth/drive']
     cred_paths = _default_cred_paths()
     cred_path = None
@@ -42,12 +45,14 @@ def read_sheet() -> list[dict[str, str]]:
         if os.path.exists(e):
             cred_path = e
             break
-    if cred_path is None:
-        logger.info("Missing credentials.json while using templated config file")
-        sys.exit(-1)
-    credentials = ServiceAccountCredentials.from_json_keyfile_name(cred_path, scopes)
-    file = gspread.auth.authorize(credentials)
-    sheet = file.open("ANL lab HW enablement clusters and connections")
+    try:
+        if cred_path is None:
+            raise ValueError(f"Credentials not found in {cred_paths}")
+        credentials = ServiceAccountCredentials.from_json_keyfile_name(cred_path, scopes)
+        file = gspread.auth.authorize(credentials)
+        sheet = file.open(SHEET)
+    except Exception as e:
+        raise ValueError(f"Failure accessing google sheet: {e}. See https://docs.gspread.org/en/latest/oauth2.html#for-bots-using-service-account and share {repr(SHEET)} sheet ( {URL} )")
     sheet1 = sheet.sheet1
     return [{k: str(v) for k, v in record.items()} for record in sheet1.get_all_records()]
 
@@ -55,7 +60,6 @@ def read_sheet() -> list[dict[str, str]]:
 def load_all_cluster_info() -> dict[str, ClusterInfo]:
     cluster = None
     ret = []
-    logger.info("loading cluster information")
     for row in read_sheet():
         if row["Name"].startswith("Cluster"):
             if cluster is not None:
@@ -87,19 +91,15 @@ def load_all_cluster_info() -> dict[str, ClusterInfo]:
 
 def validate_cluster_info(cluster_info: ClusterInfo) -> None:
     if cluster_info.provision_host == "":
-        logger.info(f"Provision host missing for cluster {cluster_info.name}")
-        sys.exit(-1)
+        raise ValueError(f"Provision host missing for cluster {cluster_info.name}")
     if cluster_info.network_api_port == "":
-        logger.info(f"Network api port missing for cluster {cluster_info.name}")
-        sys.exit(-1)
+        raise ValueError(f"Network api port missing for cluster {cluster_info.name}")
     for e in cluster_info.workers:
         if e == "":
-            logger.info("Unnamed worker found for cluster {cluster_info.name}")
-            sys.exit(-1)
+            raise ValueError(f"Unnamed worker found for cluster {cluster_info.name}")
     for e in cluster_info.bmcs:
         if e == "":
-            logger.info("Unfilled IMPI address found for cluster {cluster_info.name}")
-            sys.exit(-1)
+            raise ValueError(f"Unfilled IMPI address found for cluster {cluster_info.name}")
 
 
 def load_cluster_info(provision_host: str) -> ClusterInfo:

--- a/clusterInfo.py
+++ b/clusterInfo.py
@@ -1,3 +1,4 @@
+import dataclasses
 import os
 import gspread
 import tenacity
@@ -9,18 +10,18 @@ SHEET = "ANL lab HW enablement clusters and connections"
 URL = "https://docs.google.com/spreadsheets/d/1lXvcodJ8dmc_hcp0hzbPDU8t6-hCnAlEWFRdM2r_n0Q"
 
 
+@dataclasses.dataclass(kw_only=True)
 class ClusterInfo:
-    def __init__(self, name: str):
-        self.name = name
-        self.provision_host = ""
-        self.network_api_port = ""
-        self.iso_server = ""
-        self.organization_id = ""
-        self.activation_key = ""
-        self.bmc_hostname = []  # type: list[str]
-        self.dpu_mac_addresses = []  # type: list[str]
-        self.workers = []  # type: list[str]
-        self.bmcs = []  # type: list[str]
+    name: str
+    provision_host: str = ""
+    network_api_port: str = ""
+    iso_server: str = ""
+    organization_id: str = ""
+    activation_key: str = ""
+    bmc_hostname: list[str] = dataclasses.field(default_factory=list)
+    dpu_mac_addresses: list[str] = dataclasses.field(default_factory=list)
+    workers: list[str] = dataclasses.field(default_factory=list)
+    bmcs: list[str] = dataclasses.field(default_factory=list)
 
 
 def _default_cred_paths() -> list[str]:
@@ -64,7 +65,7 @@ def load_all_cluster_info() -> dict[str, ClusterInfo]:
         if row["Name"].startswith("Cluster"):
             if cluster is not None:
                 ret.append(cluster)
-            cluster = ClusterInfo(row["Name"])
+            cluster = ClusterInfo(name=row["Name"])
         if cluster is None:
             continue
         if row["Name"] == "Other servers":


### PR DESCRIPTION
We have cluster-info in the [ANL lab list](https://docs.google.com/spreadsheets/d/1lXvcodJ8dmc_hcp0hzbPDU8t6-hCnAlEWFRdM2r_n0Q/edit?gid=0#gid=0). There is `clusterInfo` module to fetch that data from CDA.

That is currently used whenever we have a cluster config with Jinja2 template values. Those values come from the cluster info spread sheet.

Note that dpu-operator's `make e2e-test` can only run on certain clusters/hosts that are suitable for the test to run. dpu-operator currently does not directly detect the cluster/host, however, it's [`hack/cluster-configs`](https://github.com/openshift/dpu-operator/tree/3b8c5dc3bb11393be82bcbe92ca25c4ba9b5bc74/hack/cluster-configs) contains Jinja2 fields. So when dpu-operator runs CDA-deploy, the latter will detect the current hostname (`hostname -f`) and complete the cluster config YAML with the information from the spread sheet.

So far so good. However, dpu-operator will want to directly fetch some cluster information. It should use the same data, that is, it should be able to fetch the same google spread sheet.

Extend the code in CDA's `clusterInfo.py` and make it executable. We can now call that to fetch the cluster information.

```
$ python clusterInfo.py --help
usage: clusterInfo.py [-h] [-m {sheet,all,hosts,host,card-type}] [-H HOST] [-c CLUSTER] [--credential CREDENTIAL] [--no-validate]

Load Cluster Info 'ANL lab HW enablement clusters and connections' from 'https://docs.google.com/spreadsheets/d/1lXvcodJ8dmc_hcp0hzbPDU8t6-hCnAlEWFRdM2r_n0Q'

options:
  -h, --help            show this help message and exit
  -m, --mode {sheet,all,hosts,host,card-type}
                        What information to request. Defaults to "all".
  -H, --host HOST       The host for which to fetch the cluster info (needed by some modes). Defaults to '$HOSTNAME' unless "--cluster" is specified.
  -c, --cluster CLUSTER
                        Similar to "--host" to select a cluster. This is a regular expression.
  --credential CREDENTIAL
                        The credential file to access the google doc. Defaults to "$CDA_CLUSTERINFO_CREDENTIALS" (unset) or ['$PWD/credentials.json', '$HOME/credentials.json',
                        '$HOME/.config/gspread/credentials.json'].
  --no-validate         Skip validation of cluster infos.
```

dpu-operator's `make e2e-test` will in particular be interested in calling `python clusterInfo.py -m card-type`. This will give either `dpu` or `marvell-dpu`. Then the script will call `cluster-deployment-automation/cda.py ./hack/cluster-configs/config-$CARD_TYPE.yaml` to select the correct CDA cluster config to use.

But the tool is useful in general. For example, just do run `python clusterInfo.py -m all` to see how the spread sheet values are parsed (for example to validate that the spread sheet still looks reasonable).