### PR TITLE
[th/marvell-dpu-fixes] marvell: fix isoCluster for marvell DPU

### DIFF
--- a/isoCluster.py
+++ b/isoCluster.py
@@ -9,8 +9,20 @@ import host
 
 
 def _pxeboot_marvell_dpu(name: str, bmc: BmcConfig, mac: str, ip: str, iso: str) -> None:
+    # For Marvell DPU, we require that our "BMC" is the host on has the DPU
+    # plugged in.
+    #
+    # We also assume, that the user name is "core" and that we can SSH into
+    # that host with public key authentication. We ignore the `bmc.user`
+    # setting. The reason for that is so that dpu-operator's
+    # "hack/cluster-config/config-dpu.yaml" (which should work with IPU and
+    # Marvell DPU) does not need to specify different BMC user name and
+    # passwords. If you solve how to express the BMC authentication in the
+    # cluster config in a way that is suitable for IPU and Marvell DPU at the
+    # same time (e.g. via Jinja2 templates), we can start honoring
+    # bmc.user/bmc.password.
     rsh = host.RemoteHost(bmc.url)
-    rsh.ssh_connect(bmc.user, bmc.password)
+    rsh.ssh_connect("core")
 
     ip_addr = f"{ip}/24"
     ip_gateway, _ = dhcpConfig.get_subnet_range(ip, "255.255.255.0")

--- a/isoCluster.py
+++ b/isoCluster.py
@@ -2,14 +2,15 @@ import os
 import shlex
 from clustersConfig import ClustersConfig
 from clustersConfig import NodeConfig
+from bmc import BmcConfig
 import dhcpConfig
 import common
 import host
 
 
-def _pxeboot_marvell_dpu(name: str, node: str, mac: str, ip: str, iso: str) -> None:
-    rsh = host.RemoteHost(node)
-    rsh.ssh_connect("core")
+def _pxeboot_marvell_dpu(name: str, bmc: BmcConfig, mac: str, ip: str, iso: str) -> None:
+    rsh = host.RemoteHost(bmc.url)
+    rsh.ssh_connect(bmc.user, bmc.password)
 
     ip_addr = f"{ip}/24"
     ip_gateway, _ = dhcpConfig.get_subnet_range(ip, "255.255.255.0")
@@ -57,7 +58,8 @@ def _pxeboot_marvell_dpu(name: str, node: str, mac: str, ip: str, iso: str) -> N
 
 def MarvellIsoBoot(cc: ClustersConfig, node: NodeConfig, iso: str) -> None:
     assert node.ip is not None
-    _pxeboot_marvell_dpu(node.name, node.node, node.mac, node.ip, iso)
+    assert node.bmc is not None
+    _pxeboot_marvell_dpu(node.name, node.bmc, node.mac, node.ip, iso)
     dhcpConfig.configure_iso_network_port(cc.network_api_port, node.ip)
     dhcpConfig.configure_dhcpd(node)
 

--- a/isoDeployer.py
+++ b/isoDeployer.py
@@ -63,8 +63,7 @@ class IsoDeployer(BaseDeployer):
             assert bmc is not None
             h = host.RemoteHost(bmc.url)
             h.ssh_connect(bmc.user, bmc.password)
-            # TODO, check if pci dev is marvell
-            return False
+            return "177d:b900" in h.run("lspci -nn -d :b900").out
 
         assert self._master.kind == "dpu"
         assert self._master.bmc is not None


### PR DESCRIPTION
- implement the dection of marvell hosts (checking lspci, which is similar to what dpu-operator does).

- using NodeConfig.node is not right. We want to use NodeConfig.bmc to reach the host.