### PR TITLE
deployment: Fail installation when one of the masters fail

### DIFF
--- a/assistedInstaller.py
+++ b/assistedInstaller.py
@@ -23,6 +23,7 @@ class AssistedClientHostInfo:
     name: str
     id: str
     status: str
+    status_info: str
     inventory: str
 
 
@@ -182,7 +183,7 @@ class AssistedClientAutomation(AssistedClient):  # type: ignore
     def list_ai_hosts(self) -> list[AssistedClientHostInfo]:
         ret = []
         for h in filter(lambda x: "inventory" in x, self.list_hosts()):
-            ret.append(AssistedClientHostInfo(h["requested_hostname"], h["id"], h["status"], h["inventory"]))
+            ret.append(AssistedClientHostInfo(h["requested_hostname"], h["id"], h["status"], h["status_info"], h["inventory"]))
         return ret
 
     def get_ai_host(self, name: str) -> Optional[AssistedClientHostInfo]:


### PR DESCRIPTION
The master cannot be easily retried as workers, fail the whole installation if one of the masters fail to install. This is needed instead of the callback trick. The callback trick will fail, however the futures will keep running and there isn't any way to stop them so the whole installation gets stuck anyway.