### PR TITLE
[th/is-marvell-fix] marvell: move is_marvell() detection and use correct ssh user

### DIFF
--- a/isoCluster.py
+++ b/isoCluster.py
@@ -8,7 +8,7 @@ import common
 import host
 
 
-def _pxeboot_marvell_dpu(name: str, bmc: BmcConfig, mac: str, ip: str, iso: str) -> None:
+def marvell_bmc_rsh(bmc: BmcConfig) -> host.Host:
     # For Marvell DPU, we require that our "BMC" is the host on has the DPU
     # plugged in.
     #
@@ -23,6 +23,16 @@ def _pxeboot_marvell_dpu(name: str, bmc: BmcConfig, mac: str, ip: str, iso: str)
     # bmc.user/bmc.password.
     rsh = host.RemoteHost(bmc.url)
     rsh.ssh_connect("core")
+    return rsh
+
+
+def is_marvell(bmc: BmcConfig) -> bool:
+    rsh = marvell_bmc_rsh(bmc)
+    return "177d:b900" in rsh.run("lspci -nn -d :b900").out
+
+
+def _pxeboot_marvell_dpu(name: str, bmc: BmcConfig, mac: str, ip: str, iso: str) -> None:
+    rsh = marvell_bmc_rsh(bmc)
 
     ip_addr = f"{ip}/24"
     ip_gateway, _ = dhcpConfig.get_subnet_range(ip, "255.255.255.0")

--- a/isoDeployer.py
+++ b/isoDeployer.py
@@ -58,13 +58,6 @@ class IsoDeployer(BaseDeployer):
             logger.info(f"{k}: {v.duration()}")
 
     def _deploy_master(self) -> None:
-        def is_marvell() -> bool:
-            bmc = self._master.bmc
-            assert bmc is not None
-            h = host.RemoteHost(bmc.url)
-            h.ssh_connect(bmc.user, bmc.password)
-            return "177d:b900" in h.run("lspci -nn -d :b900").out
-
         assert self._master.kind == "dpu"
         assert self._master.bmc is not None
         ipu_bmc = ipu.IPUBMC(self._master.bmc)
@@ -75,7 +68,7 @@ class IsoDeployer(BaseDeployer):
             future = executor.submit(node.start, self._cc.install_iso)
             future.result()
             node.post_boot()
-        elif is_marvell():
+        elif isoCluster.is_marvell(self._master.bmc):
             isoCluster.MarvellIsoBoot(self._cc, self._master, self._cc.install_iso)
         else:
             logger.error("Unknown DPU")


### PR DESCRIPTION
_pxeboot_marvell_dpu() already hard coded the user name "core" for ssh-ing into the DPU's host.

We also need to do that earlier, during is_marvell(), because we assume that bmc.user is not actually correct. See commit 4e24fedc931e ('marvell: hard code the BMC user name "core"') why that is done.

While at it, move is_marvell() to isoCluster.py, beside the other marvell related functions.