### PR TITLE
[th/cluster-info-iso-port] clusterInfo: add "iso_network_api_port"

### DIFF
--- a/clusterInfo.py
+++ b/clusterInfo.py
@@ -23,7 +23,7 @@ SCOPES = ("https://www.googleapis.com/auth/spreadsheets", "https://www.googleapi
 class ClusterInfo:
     name: str
     provision_host: str = ""
-    network_api_port: str = ""
+    primary_network_port: str = ""
     secondary_network_port: str = ""
     iso_server: str = ""
     organization_id: str = ""
@@ -115,7 +115,7 @@ def load_all_cluster_info(
             cluster.organization_id = row["Organization ID"]
         if row["Provision host"] in ("yes", "primary"):
             cluster.provision_host = row["Name"]
-            cluster.network_api_port = row["Ports"]
+            cluster.primary_network_port = row["Ports"]
         elif row["Provision host"] == "no":
             cluster.workers.append(row["Name"])
             bmc_host = row["BMC/IMC hostname"][8:] if "https://" in row["BMC/IMC hostname"] else row["BMC/IMC hostname"]
@@ -130,7 +130,7 @@ def load_all_cluster_info(
 def validate_cluster_info(cluster_info: ClusterInfo) -> None:
     if cluster_info.provision_host == "":
         raise ValueError(f"Provision host missing for cluster {cluster_info.name}")
-    if cluster_info.network_api_port == "":
+    if cluster_info.primary_network_port == "":
         raise ValueError(f"Network api port missing for cluster {cluster_info.name}")
     for e in cluster_info.workers:
         if e == "":

--- a/clusterInfo.py
+++ b/clusterInfo.py
@@ -24,6 +24,7 @@ class ClusterInfo:
     name: str
     provision_host: str = ""
     network_api_port: str = ""
+    secondary_network_port: str = ""
     iso_server: str = ""
     organization_id: str = ""
     activation_key: str = ""
@@ -119,6 +120,8 @@ def load_all_cluster_info(
             cluster.workers.append(row["Name"])
             bmc_host = row["BMC/IMC hostname"][8:] if "https://" in row["BMC/IMC hostname"] else row["BMC/IMC hostname"]
             cluster.bmcs.append(bmc_host)
+        if row["Provision host"] == "secondary":
+            cluster.secondary_network_port = row["Ports"]
     if cluster is not None:
         ret.append(cluster)
     return {x.provision_host: x for x in ret}

--- a/clusterInfo.py
+++ b/clusterInfo.py
@@ -113,7 +113,7 @@ def load_all_cluster_info(
             cluster.iso_server = row["ISO server"]
             cluster.activation_key = row["Activation Key"]
             cluster.organization_id = row["Organization ID"]
-        if row["Provision host"] == "yes":
+        if row["Provision host"] in ("yes", "primary"):
             cluster.provision_host = row["Name"]
             cluster.network_api_port = row["Ports"]
         elif row["Provision host"] == "no":

--- a/clustersConfig.py
+++ b/clustersConfig.py
@@ -425,6 +425,11 @@ class ClustersConfig:
             assert self._cluster_info is not None
             return self._cluster_info.network_api_port
 
+        def secondary_network_port() -> str:
+            self._ensure_clusters_loaded()
+            assert self._cluster_info is not None
+            return self._cluster_info.secondary_network_port
+
         def iso_server() -> str:
             self._ensure_clusters_loaded()
             assert self._cluster_info is not None
@@ -456,6 +461,7 @@ class ClustersConfig:
         template.globals['worker_number'] = worker_number
         template.globals['worker_name'] = worker_name
         template.globals['api_network'] = api_network
+        template.globals['secondary_network_port'] = secondary_network_port
         template.globals['iso_server'] = iso_server
         template.globals['bmc'] = bmc
         template.globals['activation_key'] = activation_key

--- a/clustersConfig.py
+++ b/clustersConfig.py
@@ -420,10 +420,10 @@ class ClustersConfig:
             assert self._cluster_info is not None
             return self._cluster_info.bmcs[a]
 
-        def api_network() -> str:
+        def primary_network_port() -> str:
             self._ensure_clusters_loaded()
             assert self._cluster_info is not None
-            return self._cluster_info.network_api_port
+            return self._cluster_info.primary_network_port
 
         def secondary_network_port() -> str:
             self._ensure_clusters_loaded()
@@ -460,7 +460,8 @@ class ClustersConfig:
         template = jinja2.Template(format_string)
         template.globals['worker_number'] = worker_number
         template.globals['worker_name'] = worker_name
-        template.globals['api_network'] = api_network
+        template.globals['primary_network_port'] = primary_network_port
+        template.globals['api_network'] = primary_network_port
         template.globals['secondary_network_port'] = secondary_network_port
         template.globals['iso_server'] = iso_server
         template.globals['bmc'] = bmc


### PR DESCRIPTION
The spreadsheet can now have a value "secondary" in the "Provision host"
column. I already updated the spreadsheet already to contain this entry.

In that case, the "Ports" column contains the "ClusterInfo.secondary_network_port".

This is also accessible in Jinja2 like

    network_api_port: {{ secondary_network_port() }}

We need this for the Marvell DPU clusters.

Note that with cluster-kind "iso" deployments, the
"secondary_network_port" of the cluster configuration has a different
(but useful) meaning than from "openshift" kinds. On all IPU clusters,
this value is currently "eno12409". On all Marvell DPU clusters, it is
currently "eno2".

As we want that a single cluster configuration works for our IPU and
Marvell DPU clusters, and as this port differs between clusters, we must
make it configurable. Do so.

In Jinja2, we can now set {{iso_network_api_port()}}. That's akin to
`network_api_port: {{ api_network() }}` which is the primary port for
for OCP clusters.

---

Also, `clusterInfo: accept "primary" for "Provision host" column`
