### PR TITLE
[th/wait-worker-rename] clusterDeployer: increase wait-time for worker node

### DIFF
--- a/clusterDeployer.py
+++ b/clusterDeployer.py
@@ -512,7 +512,7 @@ class ClusterDeployer(BaseDeployer):
             logger.error(f"Worker {node.config.name} doesn't have an IP in range {ip_range}.")
             return False
 
-        for try_count in range(30):
+        for try_count in range(60):
             info = self._ai.get_ai_host_by_ip(node.ip())
             if info is not None:
                 self._ai.update_host(info.id, {"name": node.config.name})


### PR DESCRIPTION
This wait time seems too short for some setups. We give up too early, and retry installing (booting) the worker node from scratch. Eventually, it tends to pass if we are lucky and the node is fast enough.

Double the wait time from 5 to 10 minutes.