### PR TITLE
Initial state file implementation. 

### DIFF
--- a/arguments.py
+++ b/arguments.py
@@ -86,7 +86,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument('config', metavar='config', type=str, help='Yaml file with config').completer = yaml_completer  # type: ignore
     parser.add_argument('-v', '--verbosity', choices=['debug', 'info', 'warning', 'error', 'critical'], default='info', help='Set the logging level (default: info)')
     parser.add_argument('--secret', dest='secrets_path', default='', action='store', type=str, help='pull_secret.json path (default is in cwd)')
-    parser.add_argument('--cda-config', dest='cda_config', default='/root/cda-config.yaml', action='store', type=str, help='defaults to /rooot/cda-config.yaml')
+    parser.add_argument('--cda-config', dest='cda_config', default='/root/cda-config.yaml', action='store', type=str, help='defaults to /root/cda-config.yaml')
     parser.add_argument('--assisted-installer-url', dest='url', default='192.168.122.1', action='store', type=str, help='If set to 0.0.0.0 (the default), Assisted Installer will be started locally')
 
     subparsers = parser.add_subparsers(title='subcommands', dest='subcommand')
@@ -95,6 +95,7 @@ def parse_args() -> argparse.Namespace:
 
     deploy_parser = subparsers.add_parser('deploy', help='Deploy clusters', epilog=config_list, formatter_class=argparse.RawDescriptionHelpFormatter)
     deploy_parser.add_argument('-t', '--teardown', dest='teardown', action='store_true', help='Remove anything that would be created by setting up the cluster(s)')
+    deploy_parser.add_argument('--resume', dest='resume', action='store_true', help='Continue deployment from state file')
     deploy_parser.add_argument('-f', '--teardown-full', dest='teardown_full', action='store_true', help='Remove anything that would be created by setting up the cluster(s), included ai')
 
     deploy_parser.add_argument('-s', '--steps', dest='steps', type=str, default=join_valid_steps(), help=f'Comma-separated list of steps to run (by default: {join_valid_steps()})').completer = step_completer  # type: ignore
@@ -106,6 +107,8 @@ def parse_args() -> argparse.Namespace:
     snapshot_parser = subparsers.add_parser('snapshot', help='Take or restore snapshots')
     snapshot_parser.add_argument('loadsave', metavar='loadsave', type=str, help='Load or save a snapshot', choices=(("load", "save")))
     snapshot_parser.add_argument('--name', type=str, default=None, help="Name of the snapshot (default is name of cluster)")
+
+    subparsers.add_parser('state', help='View deployment state')
 
     argcomplete.autocomplete(parser)
 

--- a/cdaConfig.py
+++ b/cdaConfig.py
@@ -6,6 +6,7 @@ class CdaConfig(configLoader.StrictBaseModel):
     token_user: str
     token: str
     credentials: str = os.path.join(os.environ["HOME"], ".config/gspread/credentials.json")
+    state_file_dir: str = os.path.join(os.environ["HOME"], ".config/cda/state/")
 
 
 def main() -> None:

--- a/state_file.py
+++ b/state_file.py
@@ -1,0 +1,50 @@
+import os
+import json
+
+
+class StateFile:
+    default_dict = {
+        "cluster-name": "",
+        "pre-step": "offline",
+        "masters": "offline",
+        "workers": "offline",
+        "post-step": "offline",
+    }
+
+    def __init__(self, path: str) -> None:
+        self.path = path
+        if not os.path.exists(path):
+            self.clear_state()
+            dir = os.path.dirname(path)
+            if dir != '':
+                os.makedirs(dir, exist_ok=True)
+        self["cluster-name"] = os.path.basename(path)
+
+    def _load_state(self) -> dict[str, str]:
+        with open(self.path, 'r') as f:
+            return dict[str, str](json.load(f))
+
+    def _save_state(self, state: dict[str, str]) -> None:
+        with open(self.path, 'w') as f:
+            f.write(json.dumps(state))
+
+    def cluster_name(self) -> str:
+        return self._load_state()["cluster-name"]
+
+    def not_deployed(self, name: str) -> bool:
+        return self._load_state()[name] == "offline"
+
+    def clear_state(self) -> None:
+        self._save_state(self.default_dict)
+
+    def __getitem__(self, key: str) -> str | None:
+        state = self._load_state()
+        return state.get(key)
+
+    def __setitem__(self, key: str, value: str) -> None:
+        state = self._load_state()
+        state[key] = value
+        self._save_state(state)
+
+    def formatted(self) -> None:
+        print(json.dumps(self._load_state(), indent=4))


### PR DESCRIPTION
deploy --resume
state subcommand  
--reset 

Currently only one state file at a time. If a new config is deployed the state gets cleared (even if the cluster is still deployed).

If a step is interrupted halfway through, resuming will restart the whole step. 

Without --resume, clusters will always be redeployed as they are currently. 