### PR TITLE
Revert Intel IPU SDK1.8 specific workarounds and enable SDK2.0 changes

### DIFF
--- a/clustersConfig.py
+++ b/clustersConfig.py
@@ -59,7 +59,7 @@ class ExtraConfigArgs:
 
     base_image: str = ""
 
-    mev_version: str = "1.8.0.10052"  # latest supported fw version
+    mev_version: str = "2.0.0.11126"  # latest supported fw version
 
     force_firmware_update: bool = False
 

--- a/dpuVendor.py
+++ b/dpuVendor.py
@@ -39,13 +39,17 @@ class VendorPlugin(ABC):
 
 
 class IpuPlugin(VendorPlugin):
-    P4_URL = "wsfd-advnetlab-amp04.anl.eng.bos2.dc.redhat.com/p4_1.8.tar.gz"
+    P4_URL = "wsfd-advnetlab-amp04.anl.eng.bos2.dc.redhat.com/intel-ipu-acc-components-2.0.0.11126.tar.gz"
 
     def __init__(self) -> None:
         pass
 
     def build_push_start(self, acc: host.Host, imgReg: ImageRegistry) -> None:
         # Config huge pages and pull vsp-p4sde
+        # The actual vsp init is done by the dpu-daemon
+        # and vsp-p4 init is done by vsp
+        # lh.run_or_die(f"podman pull --tls-verify=false {imgReg.url()}/intel-vsp-p4:dev")
+
         self.download_p4_tar(acc)
         self.configure_p4_hugepages(acc)
 
@@ -54,6 +58,9 @@ class IpuPlugin(VendorPlugin):
         rh.run_or_die(f"curl -L {self.P4_URL} -o /tmp/p4.tar.gz")
         rh.run("rm -rf /opt/p4")
         rh.run_or_die("tar -U -C /opt/ -xzf /tmp/p4.tar.gz")
+        rh.run("mv /opt/intel-ipu-acc-components-2.0.0.11126 /opt/p4")
+        rh.run("mv /opt/p4/p4-cp /opt/p4/p4-cp-nws")
+        rh.run("mv /opt/p4/p4-sde /opt/p4/p4sde")
 
     def configure_p4_hugepages(self, rh: host.Host) -> None:
         logger.info("Configuring hugepages for p4 pod")

--- a/ipu.py
+++ b/ipu.py
@@ -175,7 +175,6 @@ if [ -d "$WORKDIR" ]; then
 fi
 cd $CURDIR
 date -s "Thu Sep 19 08:18:22 AM EDT 2024"
-cp /work/redfish/redfish-1.8-iso-filesize-hotfix /usr/bin/ipu-redfish-server
 cp /work/redfish/certs/server.key /etc/pki/ca-trust/source/anchors/
 cp /work/redfish/certs/server.crt /etc/pki/ca-trust/source/anchors/
 rm -rf /home/root/MtRemoteRunner # workaround to free up some space: https://issues.redhat.com/browse/IIC-372
@@ -189,10 +188,6 @@ systemctl restart redfish
         imc.run("mkdir -pm 0700 /work/redfish/certs")
         imc.run("chmod 0700 /work/redfish")
         imc.run("chmod 0700 /work/redfish/certs")
-
-        # WA: default MeV 1.8 Redfish silently fails when booting isos above 9.5GB, install MeV 1.20 Redfish binary in the meantime
-        server.copy_from("/root/webserver/redfish-1.8-iso-filesize-hotfix", "/tmp/redfish-1.8-iso-filesize-hotfix")
-        imc.copy_to("/tmp/redfish-1.8-iso-filesize-hotfix", "/work/redfish/redfish-1.8-iso-filesize-hotfix")
         imc.write("/work/redfish/certs/server.crt", server.read_file("/root/.local-container-registry/domain.crt"))
         imc.write("/work/redfish/certs/server.key", server.read_file("/root/.local-container-registry/domain.key"))
 

--- a/ipu.py
+++ b/ipu.py
@@ -175,8 +175,6 @@ if [ -d "$WORKDIR" ]; then
 fi
 cd $CURDIR
 date -s "Thu Sep 19 08:18:22 AM EDT 2024"
-cp /work/cli_fix/libmev_imc_ipumgmtd.so /usr/lib64
-cp /work/cli_fix/ipumgmtd /usr/bin
 cp /work/redfish/redfish-1.8-iso-filesize-hotfix /usr/bin/ipu-redfish-server
 cp /work/redfish/certs/server.key /etc/pki/ca-trust/source/anchors/
 cp /work/redfish/certs/server.crt /etc/pki/ca-trust/source/anchors/
@@ -195,15 +193,6 @@ systemctl restart redfish
         # WA: default MeV 1.8 Redfish silently fails when booting isos above 9.5GB, install MeV 1.20 Redfish binary in the meantime
         server.copy_from("/root/webserver/redfish-1.8-iso-filesize-hotfix", "/tmp/redfish-1.8-iso-filesize-hotfix")
         imc.copy_to("/tmp/redfish-1.8-iso-filesize-hotfix", "/work/redfish/redfish-1.8-iso-filesize-hotfix")
-
-        # WA: There is a cli-client concurrency issue that can cause the vsp to fail. The fix will be in MeV 1.20, for now install
-        # the hotfixed binaries
-        imc.run("mkdir -pm 0700 /work/cli_fix")
-        server.copy_from("/root/webserver/ipu-mgmt-hotfix/ipumgmtd", "/tmp/ipumgmtd")
-        server.copy_from("/root/webserver/ipu-mgmt-hotfix/libmev_imc_ipumgmtd.so", "/tmp/libmev_imc_ipumgmtd.so")
-        imc.copy_to("/tmp/ipumgmtd", "/work/cli_fix/ipumgmtd")
-        imc.copy_to("/tmp/libmev_imc_ipumgmtd.so", "/work/cli_fix/libmev_imc_ipumgmtd.so")
-
         imc.write("/work/redfish/certs/server.crt", server.read_file("/root/.local-container-registry/domain.crt"))
         imc.write("/work/redfish/certs/server.key", server.read_file("/root/.local-container-registry/domain.key"))
 

--- a/ipu.py
+++ b/ipu.py
@@ -194,14 +194,13 @@ systemctl restart redfish
         imc.write("/work/scripts/pre_init_app.sh", script)
         # WA: use idpf for ACC to IMC. Remove when we've moved to icc-net:
         # https://issues.redhat.com/browse/IIC-485
-        contents = "{\"init_app_acc_nboot_net_name\": \"enp0s1f0\"}"  # Soon, this will not be required anymore
-
+        imc.run("/usr/bin/imc-scripts/cfg_boot_options \"init_app_acc_nboot_net_name\" \"enp0s1f0\"")
+        imc.run("/usr/bin/imc-scripts/cfg_boot_options \"init_app_acc_nboot_stage\"  \"2\"")
         # When developing / frequently re-deploying the ACC, we can update the watchdog timeout to avoid ending up in recovery mode
         # https://issues.redhat.com/browse/IIC-369
         acc_config = imc.read_file("/mnt/imc/acc_variable/acc-config.json")
         imc.write("/mnt/imc/acc_variable/acc-config.json", acc_config.replace("\"acc_watchdog_timer\": 60", "\"acc_watchdog_timer\": 9999"))
 
-        imc.write("/work/cfg/config.json", contents)
         imc.run("mkdir -m 0700 /work/redfish")
         imc.run("cp /etc/imc-redfish-configuration.json /work/redfish/")
         imc.run(f"echo {self.password} | bash /usr/bin/ipu-redfish-generate-password-hash.sh")


### PR DESCRIPTION
Revert Intel IPU SDK1.8 specific workarounds and enable SDK2.0 changes