### PR TITLE
Remove workaround added in the past to free up some space on IMC

### DIFF
--- a/ipu.py
+++ b/ipu.py
@@ -174,7 +174,6 @@ cd $CURDIR
 date -s "Thu Sep 19 08:18:22 AM EDT 2024"
 cp /work/redfish/certs/server.key /etc/pki/ca-trust/source/anchors/
 cp /work/redfish/certs/server.crt /etc/pki/ca-trust/source/anchors/
-rm -rf /home/root/MtRemoteRunner # workaround to free up some space: https://issues.redhat.com/browse/IIC-372
 update-ca-trust
 sleep 10 # wait for ip address so that redfish starts with that in place
 systemctl restart redfish


### PR DESCRIPTION
This workaround is not required with the latest IPU SDK update.