### PR TITLE
Prevent ACC boot issue mentioning DRAM interface

### DIFF
--- a/ipu.py
+++ b/ipu.py
@@ -223,7 +223,7 @@ systemctl restart redfish
         # WA: use idpf for ACC to IMC. Remove when we've moved to icc-net:
         # https://issues.redhat.com/browse/IIC-485
         imc.run("/usr/bin/imc-scripts/cfg_boot_options \"init_app_acc_nboot_net_name\" \"enp0s1f0\"")
-        imc.run("/usr/bin/imc-scripts/cfg_boot_options \"init_app_acc_nboot_stage\"  \"2\"")
+        imc.run("/usr/bin/imc-scripts/cfg_boot_options \"init_app_acc_nboot_stage\"  \"0\"")
         # When developing / frequently re-deploying the ACC, we can update the watchdog timeout to avoid ending up in recovery mode
         # https://issues.redhat.com/browse/IIC-369
         if imc.exists("/mnt/imc/acc_variable/acc-config.json"):


### PR DESCRIPTION
Addresses IIC-640 which intermittently saw this upon ACC boot:
Error: Timed out while waiting for response from the shared DRAM interface. Stopping boot.

At one point, we were advised to set the init_app_acc_nboot_stage option to 2. This guidance has changed to 0, this makes the IMC wait a little bit longer before trying to start the ACC.