### PR TITLE
[th/assisted-installer-update-images] assisted-installer: update version of installer images

### DIFF
--- a/assistedInstallerService.py
+++ b/assistedInstallerService.py
@@ -78,12 +78,12 @@ non-standard way, the web-ui can't be used.
 class AssistedInstallerService:
     # Freeze SAAS version to avoid unexpected breakages.
     # The values are taken from:
-    # https://gitlab.cee.redhat.com/service/app-interface/-/blob/ee5f631ce539537085b5ef043bbd9593fa74f860/data/services/assisted-installer/cicd/target/production/assisted-service.yaml#L44-47
+    # https://gitlab.cee.redhat.com/service/app-interface/-/blob/e8e6c61a2bc89b905d2c19c407e48876c94fa6e3/data/services/assisted-installer/cicd/target/production/assisted-service.yaml#L45-50
     #
     SAAS_VERSION = "latest"
-    INSTALLER_IMAGE = "registry.redhat.io/rhai/assisted-installer-rhel9:d50758cab25829bba67ab8250e8209b13b3e3833"
-    CONTROLLER_IMAGE = "registry.redhat.io/rhai/assisted-installer-controller-rhel9:d50758cab25829bba67ab8250e8209b13b3e3833"
-    AGENT_DOCKER_IMAGE = "registry.redhat.io/rhai/assisted-installer-agent-rhel9:8266f8816db76d47dff55ad2e319093eddccc6e7"
+    INSTALLER_IMAGE = "registry.redhat.io/rhai/assisted-installer-rhel9:0de29205c8b99bdfdc12271281d5830f185d8f8c"
+    CONTROLLER_IMAGE = "registry.redhat.io/rhai/assisted-installer-controller-rhel9:0de29205c8b99bdfdc12271281d5830f185d8f8c"
+    AGENT_DOCKER_IMAGE = "registry.redhat.io/rhai/assisted-installer-agent-rhel9:8fe07df02b9e2b92f27c8d661c9d59a95be172db"
 
     def __init__(self, version: str, ip: str, resume_deployment: bool = False, proxy: Optional[str] = None, noproxy: Optional[str] = None, branch: str = "master"):
         self._version = version


### PR DESCRIPTION
The earlier images seem broken. When installing SNO cluster with the example config from the README, it was hanging.

Update the assisted installer images, which makes it work again.