### PR TITLE
[th/fix-mypy-parse-json-list] common: avoid [redundant-cast] warning in _parse_json_list()

### DIFF
--- a/common.py
+++ b/common.py
@@ -291,7 +291,8 @@ def _parse_json_list(jstr: str, *, strict_parsing: bool = False) -> list[typing.
                 raise
             return []
 
-    return typing.cast(list[typing.Any], lst)
+    lst2: list[typing.Any] = lst
+    return lst2
 
 
 def ip_addrs_parse(jstr: str, *, strict_parsing: bool = False, ifname: Optional[str] = None) -> list[IPRouteAddressEntry]:


### PR DESCRIPTION
mypy 1.16 now better detects the type, which leads to a [redundant-cast] warning:
```
common.py:294: error: Redundant cast to "list[Any]"  [redundant-cast]
```
Older versions couldn't figure that out, so the type was `Any` and we needed the cast to avoid "[no-return-any]".

Add another workaround for the issue, which should work with older and newer mypy.