### PR TITLE
isoDeployer: drop unused import for ThreadPoolExecutor

### DIFF
--- a/isoDeployer.py
+++ b/isoDeployer.py
@@ -6,7 +6,6 @@ import marvell
 import ipu
 from baseDeployer import BaseDeployer
 from clustersConfig import ClustersConfig
-from concurrent.futures import ThreadPoolExecutor
 from dpuVendor import detect_dpu
 import sys
 import dhcpConfig


### PR DESCRIPTION
Fixes: 969a134a5b4e ('unwrap from general structure')