### PR TITLE
[th/marvell-extra-args] honor CDA_MARVELL_TOOLS_EXTRA_ARGS environment for passing arguments to pxeboot command

### DIFF
--- a/marvell.py
+++ b/marvell.py
@@ -42,6 +42,11 @@ def _pxeboot_marvell_dpu(name: str, bmc: BmcConfig, mac: str, ip: str, iso: str)
 
     ssh_key_options = [f"--ssh-key={shlex.quote(s)}" for s in ssh_keys]
 
+    extra_args = ""
+    v = os.environ.get("CDA_MARVELL_TOOLS_EXTRA_ARGS", None)
+    if v:
+        extra_args = shlex.join(shlex.split(v)) + " "
+
     image = os.environ.get("CDA_MARVELL_TOOLS_IMAGE", "quay.io/sdaniele/marvell-tools:latest")
 
     r = rsh.run(
@@ -71,6 +76,7 @@ def _pxeboot_marvell_dpu(name: str, bmc: BmcConfig, mac: str, ip: str, iso: str)
         "--default-extra-packages "
         f"{' '.join(ssh_key_options)} "
         f"{shlex.quote(iso)} "
+        f"{extra_args}"
         "2>&1 "
         "| tee \"/tmp/pxeboot-log-$(date '+%Y%m%d-%H%M%S')\""
     )


### PR DESCRIPTION
Honor the `CDA_MARVELL_TOOLS_EXTRA_ARGS` environment variable for additional arguments when calling the pxeboot script.

This can be useful to the user for testing something manually (without needing to patch the CDA sources).

But more importantly, it allows dpu-operator to inject a behavior. There is !303 which will want to set `CDA_MARVELL_TOOLS_EXTRA_ARGS="--octep-cp-agent-service-disable"`. There is a transition period where 303 is on review and in testing, while other PRs in testing still want the old behavior. It is gonna be a one-liner to set `CDA_MARVELL_TOOLS_EXTRA_ARGS="--octep-cp-agent-service-disable"` on 303. The alternative is cumbersome, because we would either need to patch CDA and pull in a separate version of CDA in the git-submodule. But usually, we only pull CDA versions from `main` branch, but we wouldn't want to change CDA on the main branch before all users want the new behavior.