### PR TITLE
fix(image-registry): Need readiness checks

### DIFF
--- a/clusterDeployer.py
+++ b/clusterDeployer.py
@@ -447,27 +447,9 @@ class ClusterDeployer(BaseDeployer):
             for worker in h.k8s_worker_nodes:
                 worker.set_password()
 
-        self._wait_cluster_ready()
         logger.info("Deploying In-Cluster Registry")
         icr = InClusterRegistry(self._cc.kubeconfig)
         icr.deploy()
-
-    def _wait_cluster_ready(self) -> None:
-        if self._client is None:
-            self._client = self.client()
-        logger.info("Waiting for all cluster operators to be ready")
-        timeout = "30s"
-        for tries in itertools.count():
-            if all(
-                rc.success()
-                for rc in [
-                    self._client.oc(f"wait co --all --for='condition=AVAILABLE=True' --timeout={timeout}"),
-                    self._client.oc(f"wait co --all --for='condition=PROGRESSING=False' --timeout={timeout}"),
-                    self._client.oc(f"wait co --all --for='condition=DEGRADED=False' --timeout={timeout}"),
-                ]
-            ):
-                logger.info(f"Cluster ready after {tries} tries")
-                break
 
     def _wait_master_reboot(self, infra_env: str, node: ClusterNode) -> bool:
         def master_ready(ai: AssistedClientAutomation, node_name: str) -> bool:


### PR DESCRIPTION
Fixes:
- Wait cluster waits over an 1 hour because of Kube-api operator and OpenShift controller operator doesn't get ready at the correct time. We don't need that check since for the image registry we check for the relevant operators readiness anyway.
- Bumps retries for waiting on default route for register to be available
- Explicitly waits after applying patches to fully apply.
- Http check for the library to make sure the image registry is up at the service/application level.