### PR TITLE
Install OCP client in dependencies.

### DIFF
--- a/dependencies.sh
+++ b/dependencies.sh
@@ -41,3 +41,7 @@ cat requirements.txt  | xargs -n1 $PYTHON_CMD -m pip install
 
 export PYTHON_CMD_FULL=$(which $PYTHON_CMD)
 sudo -E $PYTHON_CMD_FULL $(which activate-global-python-argcomplete)
+
+oc_url="https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/ocp/stable/openshift-client-linux.tar.gz"
+curl -L "$oc_url" -o /tmp/openshift-client-linux.tar.gz
+sudo tar -U -C /usr/local/bin -xzf /tmp/openshift-client-linux.tar.gz

--- a/k8sClient.py
+++ b/k8sClient.py
@@ -16,15 +16,6 @@ class K8sClient:
         self._api_client = kubernetes.config.new_client_from_config_dict(c)
         self._client = kubernetes.client.CoreV1Api(self._api_client)
         self._host = host
-        self._ensure_oc_installed()
-
-    def _ensure_oc_installed(self) -> None:
-        if self._host.run("which oc").returncode == 0:
-            return
-        uname = self._host.run_or_die("uname -m").out.strip()
-        url = f"https://mirror.openshift.com/pub/openshift-v4/{uname}/clients/ocp/stable/openshift-client-linux.tar.gz"
-        self._host.run_or_die(f"curl -L {url} -o /tmp/openshift-client-linux.tar.gz")
-        self._host.run_or_die("sudo tar -U -C /usr/local/bin -xzf /tmp/openshift-client-linux.tar.gz")
 
     def is_ready(self, name: str) -> bool:
         for e in self._client.list_node().items:


### PR DESCRIPTION
The k8sClient was ensuring that OCP client is installed, however, it wasn't ever updated once installed. Let's try to pull latest stable version during dependencies installation.