### PR TITLE
fix(assistedInstaller): Correct makedirs target

### DIFF
--- a/assistedInstaller.py
+++ b/assistedInstaller.py
@@ -104,7 +104,7 @@ class AssistedClientAutomation(AssistedClient):  # type: ignore
         logger.info(self.info_iso(infra_env, {}))
         t = timer.Timer("15m")
         logger.info(f"Download iso from {infra_env} to {path}, retrying for {t.target_duration()}")
-        os.makedirs(os.path.dirname(path), exist_ok=True)
+        os.makedirs(path, exist_ok=True)
         while not t.triggered():
             try:
                 self.download_iso(infra_env, path)


### PR DESCRIPTION
When using dirname it actually tries to make "/home" since the path provided is already to the directory instead of the iso file. To achieve the expected behavior, we actually have to use the path as is.