### PR TITLE
Install chrony on IMC

### DIFF
--- a/host.py
+++ b/host.py
@@ -401,7 +401,7 @@ class Host:
         ret = self.run(f"virsh dominfo {name}", logging.DEBUG)
         return not ret.returncode and state_running(ret.out)
 
-    def write(self, fn: str, contents: str) -> None:
+    def write(self, fn: str, contents: str, encoding: str = 'utf-8') -> None:
         dir_path = os.path.dirname(fn)
         if self.is_localhost():
             if dir_path and not os.path.exists(dir_path):
@@ -413,7 +413,7 @@ class Host:
             self.run_or_die(f"mkdir -p {dir_path}")
             with tempfile.NamedTemporaryFile(delete=False) as tmp_file:
                 tmp_filename = tmp_file.name
-                tmp_file.write(contents.encode('utf-8'))
+                tmp_file.write(contents.encode(encoding))
             self.copy_to(tmp_filename, fn)
             os.remove(tmp_filename)
 


### PR DESCRIPTION
Replace pre_init_app.sh with a version that allows new modules to be added into /work/scripts/pre_init_app.d/ for as close to a systemd ability as we can get on the current architecture.

locate the most recent chrony package on the rockylinux server, check in both /pub and /vault as they rename the folders for some reason. 

add /work/script/pre_init_app.d/chrony.sh which installs chrony (needed at every imc reboot)

start chrony during the setup phase

if a rpm file is not found, as a failsafe set the time on the imc to the time of the provisioning host. This is good enough to get the current iso installed, though redfish may have issues connecting in the future. But at least the CI test will succeed regardless

print the time reported from the imc for the sake of the logs.

Copying the rpm to the imc.write() cannot be done with utf-8 encoding, so i added an optional encoding parameter to Host