### PR TITLE
[th/bmc-base-url] bmc: ensure scheme in URL for redfish Reset

### DIFF
--- a/bmc.py
+++ b/bmc.py
@@ -20,6 +20,13 @@ class BMC:
         self.password = password
         logger.info(f"{full_url} {user} {password}")
 
+    @property
+    def base_url(self) -> str:
+        scheme = ""
+        if not self.url.startswith("https://") and not self.url.startswith("http://"):
+            scheme = "https://"
+        return f"{scheme}{self.url}"
+
     @staticmethod
     def from_bmc_config(bmc_config: BmcConfig) -> 'BMC':
         return BMC.from_bmc(bmc_config.url, bmc_config.user, bmc_config.password)
@@ -105,7 +112,7 @@ class BMC:
             for _ in range(10):
                 headers = {"Content-Type": "application/json"}
                 payload = {"ResetType": "GracefulRestart"}
-                full_url = f"{self.url}/redfish/v1/Managers/iDRAC.Embedded.1/Actions/Manager.Reset"
+                full_url = f"{self.base_url}/redfish/v1/Managers/iDRAC.Embedded.1/Actions/Manager.Reset"
                 response = requests.post(full_url, auth=(self.user, self.password), headers=headers, json=payload, verify=False)
                 if 200 <= response.status_code < 300:
                     logger.info("Command to reset redfish sent successfully")


### PR DESCRIPTION
We have

    class BMC:
        def __init__(self, full_url: str, ...):
            self.url = full_url

but call

    BMC(ip_or_hostname, user, password)

This means, some (all?) callers set the "full_url" and "self.url" to an IP address or hostname.

Later we build a complete URL, but (usually?) there is no URL scheme. This leads to

    requests.exceptions.MissingSchema: Invalid URL '10.26.16.95/redfish/v1/Managers/iDRAC.Embedded.1/Actions/Manager.Reset': No scheme supplied. Perhaps you meant https://10.26.16.95/redfish/v1/Managers/iDRAC.Embedded.1/Actions/Manager.Reset?

See-also: https://jenkins-csb-nst-net-hw-ci.dno.corp.redhat.com/job/99_E2E_Marvell_DPU_Deploy/581/console