### PR TITLE
[th/bmc-base-url-2] bmc: ensure scheme in URL for waiting for redfish Reset

### DIFF
--- a/host.py
+++ b/host.py
@@ -136,7 +136,7 @@ class AutoLogin(Login):
 
 class Host:
     def __new__(cls, hostname: str, bmc: Optional[BMC] = None) -> 'Host':
-        key = (hostname, bmc.url if bmc else None)
+        key = (hostname, bmc.bmc_host if bmc else None)
         if key not in host_instances:
             host_instances[key] = super().__new__(cls)
         return host_instances[key]


### PR DESCRIPTION
We must use an URL with a valid scheme. Otherwise, the request fails with

    requests.exceptions.MissingSchema: Invalid URL '10.26.16.95': No scheme supplied. Perhaps you meant https://10.26.16.95?

See-also: https://jenkins-csb-nst-net-hw-ci.dno.corp.redhat.com/job/99_E2E_Marvell_DPU_Deploy/593/console

---

This is a follow up fix for #365. Unfortunately, the earlier patch was not enough.