### PR TITLE
Add firewall configuration for Microshift cluster

### DIFF
--- a/extraConfigDpu.py
+++ b/extraConfigDpu.py
@@ -13,6 +13,7 @@ from dpuVendor import init_vendor_plugin
 import timer
 import re
 from dpuVendor import detect_dpu
+from firewall import enable_firewall, disable_firewall
 
 MICROSHIFT_KUBECONFIG = "/root/kubeconfig.microshift"
 
@@ -137,9 +138,9 @@ def ExtraConfigDpu(cc: ClustersConfig, cfg: ExtraConfigArgs, futures: dict[str, 
     imgReg = imageRegistry.ensure_local_registry_running(lh, delete_all=False)
     imgReg.trust(acc)
     acc.run("systemctl restart crio")
-    # Disable firewall to ensure host-side can reach dpu
-    acc.run("systemctl stop firewalld")
-    acc.run("systemctl disable firewalld")
+    # Enable and configure firewall at IPU 
+    enable_firewall(acc)
+
 
     vendor_plugin = init_vendor_plugin(acc, detect_dpu(dpu_node))
     # TODO: For Intel, this configures hugepages. Figure out a better way

--- a/extraConfigMicroshift.py
+++ b/extraConfigMicroshift.py
@@ -8,6 +8,7 @@ import host
 import yaml
 import time
 import sys
+from firewall import enable_firewall, disable_firewall
 
 
 def early_access_microshift() -> str:
@@ -88,8 +89,6 @@ def ExtraConfigMicroshift(cc: ClustersConfig, cfg: ExtraConfigArgs, futures: dic
 
     # Configure firewalld for microshift
     logger.info("Configuring firewall for microshift")
-    acc.run("systemctl disable firewalld")
-    acc.run("systemctl stop firewalld")
 
     # Adjust the timeout for microshift service to ensure it starts successfully
     acc.run_or_die("mkdir -p /etc/systemd/system/microshift.service.d/")
@@ -126,8 +125,8 @@ def ExtraConfigMicroshift(cc: ClustersConfig, cfg: ExtraConfigArgs, futures: dic
     contents = read_prep_microshift_kubeconfig(acc)
     kubeconfig = write_microshift_kubeconfig(contents, host.LocalHost())
 
-    acc.run("systemctl stop firewalld")
-    acc.run("systemctl disable firewalld")
+    # Enable and configure firewall at IPU
+    enable_firewall(acc)
 
     def cb() -> None:
         acc.run("ip r del default via 192.168.0.1")

--- a/firewall.py
+++ b/firewall.py
@@ -1,0 +1,61 @@
+import logging
+
+TRUSTED_CIDRS = ['169.254.169.0/24', '192.168.0.0/24']
+SSH_INTERFACES = ['enp0s1f0d1']
+PORT_RULES = {
+    ('internal', 'tcp'): ['8080', '443'],
+    ('public', 'tcp'): ['22', '6443', '8445', '10250-10259'],
+    ('public', 'udp'): ['53', '67-68'],
+}
+
+logger = logging.getLogger("firewall")
+
+def enable_firewall(host):
+    logger.info("Enabling and configuring firewall...")
+    host.run("systemctl enable firewalld")
+    host.run("systemctl start firewalld")
+    host.run("firewall-cmd --set-default-zone=drop")
+    host.run("firewall-cmd --permanent --new-zone=internal || true")
+
+    for cidr in TRUSTED_CIDRS:
+        host.run(f"firewall-cmd --permanent --zone=internal --add-source={cidr}")
+        host.run(f"firewall-cmd --permanent --zone=internal --add-rich-rule=rule family='ipv4' destination address='{cidr}' accept")
+
+    for (zone, proto), ports in PORT_RULES.items():
+        for port in ports:
+            host.run(f"firewall-cmd --permanent --zone={zone} --add-port={port}/{proto}")
+
+    for iface in SSH_INTERFACES:
+        host.run(f"firewall-cmd --permanent --zone=public --add-interface={iface}")
+
+    host.run("firewall-cmd --permanent --zone=drop --add-port=6443/tcp")
+    host.run("firewall-cmd --permanent --zone=public --remove-service=mdns")
+    host.run("firewall-cmd --set-log-denied=all")
+    host.run("firewall-cmd --reload")
+    logger.info("Firewall enabled and configured.")
+
+def disable_firewall(host):
+    logger.info("Disabling firewall rules and cleaning up...")
+    host.run("systemctl enable firewalld")
+    host.run("systemctl start firewalld")
+    host.run("firewall-cmd --set-default-zone=public")
+
+    for cidr in TRUSTED_CIDRS:
+        host.run(f"firewall-cmd --permanent --zone=internal --remove-source={cidr}")
+        host.run(f"firewall-cmd --permanent --zone=internal --remove-rich-rule=rule family='ipv4' destination address='{cidr}' accept")
+
+    for (zone, proto), ports in PORT_RULES.items():
+        for port in ports:
+            host.run(f"firewall-cmd --permanent --zone={zone} --remove-port={port}/{proto}")
+
+    for i, iface in enumerate(SSH_INTERFACES):
+        if i == 0:
+            continue
+        host.run(f"firewall-cmd --permanent --zone=public --remove-interface={iface}")
+
+    host.run("firewall-cmd --permanent --zone=drop --remove-port=6443/tcp")
+    host.run("firewall-cmd --permanent --zone=public --add-service=mdns")
+    host.run("firewall-cmd --set-log-denied=off")
+    host.run("firewall-cmd --permanent --delete-zone=internal || true")
+    host.run("firewall-cmd --reload")
+    logger.info("Firewall rules cleaned up and disabled.")


### PR DESCRIPTION
Configure firewall configuration for Microshift cluster running on IPU. Kubernetes.

Note that the kube-proxy and your CNI plugin program iptables rules that steer cluster traffic, but they assume those packets can reach the host in the first place.

This commit mainly handles ipu host level firewall configuration to allow the trusted kube-proxy connections.