### PR TITLE
extraConfigMicroshift: increase number of retries for installing microshift

### DIFF
--- a/extraConfigMicroshift.py
+++ b/extraConfigMicroshift.py
@@ -112,7 +112,7 @@ def ExtraConfigMicroshift(cc: ClustersConfig, cfg: ExtraConfigArgs, futures: dic
     logger.info(f"ACC date: {acc_date}")
 
     logger.info("Installing microshift")
-    acc.run_or_die("dnf install -y microshift microshift-multus", retry=3)
+    acc.run_or_die("dnf install -y microshift microshift-multus", retry=60)
     ret = acc.run(r"grep '\[crio.runtime.runtimes.crun\]' /etc/crio/crio.conf")
     if not ret.success():
         crun_conf_lines = ['[crio.runtime.runtimes.crun]', 'runtime_path = "/usr/bin/crun"', 'runtime_type = "oci"', 'runtime_root = "/run/crun"']


### PR DESCRIPTION
This command still fails, see [1].

Increase the number of retries. As there is a hard-coded sleep interval of 5 seconds, increasing to 60 means to retry for approximately 5 minutes. There really is no harm hear.

Either the error is temporary, in which case retrying long enough to workaround is good. Or it is permanant, in which case we will fail slightly later after retrying for a few minutes.

[1] https://jenkins-csb-nst-net-hw-ci.dno.corp.redhat.com/view/DPU%20Testing/job/99_E2E_Marvell_DPU_Deploy/752/console