### PR TITLE
[th/retry-download-iso] Revert "Handle errors when assisted installer goes down during iso prep"

### DIFF
--- a/assistedInstaller.py
+++ b/assistedInstaller.py
@@ -11,7 +11,6 @@ from logger import logger
 import sys
 import tenacity
 import timer
-from assistedInstallerService import AssistedInstallerService
 
 
 @dataclass
@@ -36,9 +35,8 @@ class ClusterInfo:
 
 
 class AssistedClientAutomation(AssistedClient):  # type: ignore
-    def __init__(self, url: str, ais: Optional[AssistedInstallerService]):
+    def __init__(self, url: str):
         super().__init__(url, quiet=True, debug=False)
-        self.ais = ais
 
     def cluster_exists(self, name: str) -> bool:
         return any(name == x.name for x in self.get_cluster_info_all())
@@ -111,11 +109,7 @@ class AssistedClientAutomation(AssistedClient):  # type: ignore
                 logger.info(f"Downloaded iso after {t.elapsed()}")
                 return
             except Exception:
-                pass
-            time.sleep(1)
-            if self.ais and not self.ais.healthy():
-                logger.error_and_exit("Assisted installer pods become unhealthy")
-
+                time.sleep(1)
         logger.error_and_exit(f"Failed to download the ISO after with {t.elapsed()}")
 
     def wait_cluster_status(self, cluster_name: str, status: str) -> None:

--- a/assistedInstallerService.py
+++ b/assistedInstallerService.py
@@ -589,9 +589,3 @@ class AssistedInstallerService:
 
         self.start(True)
         time.sleep(30)
-
-    def healthy(self) -> bool:
-        pod = self.find_pod("assisted-installer")
-        if pod is None:
-            return False
-        return pod["Status"] == "Running"

--- a/cda.py
+++ b/cda.py
@@ -47,7 +47,7 @@ def main_deploy_openshift(cc: ClustersConfig, args: argparse.Namespace, state_fi
     The usage details are here:
         https://aicli.readthedocs.io/en/latest/
     """
-    ai = AssistedClientAutomation(f"{args.url}:8090", ais)
+    ai = AssistedClientAutomation(f"{args.url}:8090")
     cd = ClusterDeployer(cc, ai, args.steps, args.secrets_path, state_file, args.resume)
 
     if args.additional_post_config:
@@ -88,7 +88,7 @@ def main_snapshot(args: argparse.Namespace, cc: ClustersConfig, state_file: Stat
     args = parse_args()
 
     ais = AssistedInstallerService(cc.version, args.url)
-    ai = AssistedClientAutomation(f"{args.url}:8090", ais)
+    ai = AssistedClientAutomation(f"{args.url}:8090")
 
     name = cc.name if args.name is None else args.name
     cs = ClusterSnapshotter(cc, ais, ai, name)


### PR DESCRIPTION
It is unclear what the purpose of this was. The git history does not
make that clear. There was already a retry loop, bound to 15 minutes.
Restore to only rely on the retry loop.

What happens otherise is that the first pull of the ISO fails, then the
health check fails too, aborting installation and no retry. Also, on the
next run the same thing happens again, and the cluster does not recover.
If we would actually continue trying to download the ISO, it would
recover and become healthy again. At least, usually it recovers. If not,
and AI stays broken, then there is still the useful timeout to give up
eventually. The health check is harmfull, because AI has a certain
chance to recover.

For example, see [1] and the previous failures.

This reverts commit b1681deee4443fc2080a452f6714285ffacb42d9.

[1] https://jenkins-csb-nst-net-hw-ci.dno.corp.redhat.com/view/DPU%20Testing/job/99_E2E_Marvell_DPU_Deploy/761/
