### PR TITLE
E2E image mode enablement for DPUs

### DIFF
--- a/clustersConfig.py
+++ b/clustersConfig.py
@@ -77,15 +77,16 @@ class ExtraConfigArgs:
     kickstart: Optional[str] = None
     remove_args: Optional[str] = None
 
-    registry: Optional[list[RegistryInfo]] = None
-
     # Custom OVN repo URL
     ovn_repo: Optional[str] = None
     # Custom OVN ref, it should be existing commit hash or branch
     ovn_ref: Optional[str] = None
 
     registries: Optional[list[RegistryInfo]] = None
-    import_pull_secret: bool = False
+    import_pull_secret: bool = True
+    bootc_dir: str = "rhel-image-mode-4-dpu"
+    bootc_build_local: bool = True
+    iso_builder_auth_file: Optional[str] = None
 
     def __post_init__(self) -> None:
         if self.registries is not None:

--- a/extraConfigHostRegistry.py
+++ b/extraConfigHostRegistry.py
@@ -1,5 +1,5 @@
 from concurrent.futures import Future
-from typing import Optional
+from typing import Optional, Any
 from auth import import_secret_path
 from clustersConfig import ClustersConfig
 from logger import logger
@@ -12,31 +12,25 @@ import json
 def ExtraConfigHostRegistry(cc: ClustersConfig, cfg: ExtraConfigArgs, futures: dict[str, Future[Optional[host.Result]]]) -> None:
     [f.result() for (_, f) in futures.items()]
 
-    auth_path = "/run/user/0/containers/auth.json"
-
-    # Load existing data
-    if os.path.exists(auth_path):
-        with open(auth_path, "r") as f:
-            try:
-                auth_data = json.load(f)
-            except json.JSONDecodeError:
-                logger.warning(f"{auth_path} is invalid. Resetting.")
-                auth_data = {"auths": {}}
-    else:
-        auth_data = {"auths": {}}
-
-    # Merge pull secret
-    if cfg.import_pull_secret:
-        logger.info(f"Importing secrets_path: {cc.secrets_path}")
-        auth_data["auths"].update(import_secret_path(cc.secrets_path))
-
     # Merge other user-defined registries
     if cfg.registries:
         logger.info(f"Preparing registries: {cfg.registries}")
         for r in cfg.registries:
+            auth_data: dict[str, Any] = {"auths": {}}
+            if cfg.import_pull_secret:
+                logger.info(f"Importing secrets_path: {cc.secrets_path}")
+                auth_data["auths"].update(import_secret_path(cc.secrets_path))
+            if os.path.exists(r.auth_path):
+                with open(r.auth_path, "r") as f:
+                    try:
+                        auth_data = json.load(f)
+                    except json.JSONDecodeError:
+                        logger.warning(f"{r.auth_path} is invalid. Resetting.")
+                        auth_data = {"auths": {}}
+            else:
+                auth_data = {"auths": {}}
             auth_data["auths"].update(r.prep_auth())
-
-    # Write once
-    os.makedirs(os.path.dirname(auth_path), exist_ok=True)
-    with open(auth_path, "w") as f:
-        json.dump(auth_data, f, indent=2)
+            os.makedirs(os.path.dirname(r.auth_path), exist_ok=True)
+            with open(r.auth_path, "w") as f:
+                json.dump(auth_data, f, indent=2)
+            logger.info(f"Successfully wrote {len(auth_data['auths'])} registry auth entries to {r.auth_path}")

--- a/extraConfigIsoBuilder.py
+++ b/extraConfigIsoBuilder.py
@@ -38,6 +38,9 @@ def ExtraConfigIsoBuilder(
     activation_key: str = cast(str, cfg.activation_key)
     image_mode_url: str = cfg.image_mode_url
     iso_builder_url: str = cfg.iso_builder_url
+    bootc_build_local: bool = cfg.bootc_build_local
+    bootc_dir: str = cfg.bootc_dir
+    iso_builder_auth_file: Optional[str] = cfg.iso_builder_auth_file
 
     # Optional bootc iso build params
     input_iso: Optional[str] = cfg.input_iso
@@ -52,6 +55,10 @@ def ExtraConfigIsoBuilder(
     if dpu_flavor == "ipu":
         extra_args = " ip=192.168.0.2:::255.255.255.0::enp0s1f0:off netroot=iscsi:192.168.0.1::::iqn.e2000:acc acpi=force"
         kernel_args = (kernel_args or "") + extra_args
+        remove_args = "rd.live.check"
+        grub_replacements = [
+            "timeout=60|timeout=5",
+        ]
 
     # Build the ISO
     BootcIsoBuilder(
@@ -67,4 +74,8 @@ def ExtraConfigIsoBuilder(
         kernel_args=kernel_args,
         remove_args=remove_args,
         dpu_flavor=dpu_flavor,
+        auth_file_path=iso_builder_auth_file,  # Use auth file from iso_builder config
+        bootc_build_local=bootc_build_local,
+        grub_replacements=grub_replacements,
+        bootc_dir=bootc_dir,
     ).build()

--- a/ipu.py
+++ b/ipu.py
@@ -93,9 +93,9 @@ class IPUClusterNode(ClusterNode):
         acc.ssh_connect("root", "redhat")
         logger.info(acc.run("uname -a"))
         logger.info("Connected to ACC")
-        if acc.exists("/cda-install"):
-            logger.error_and_exit("Found /cda-install file from a previous installation (install failed)")
-        acc.write("/cda-install", f"{time.time()}")
+        if acc.exists("/var/cda-install"):
+            logger.error_and_exit("Found /var/cda-install file from a previous installation (install failed)")
+        acc.write("/var/cda-install", f"{time.time()}")
 
     def start(self, iso_or_image_path: str) -> bool:
         assert self.config.bmc is not None
@@ -183,7 +183,6 @@ class IPUClusterNode(ClusterNode):
         # after an IMC reboot (which occurs during the RHEL installation)
         assert self.config.dpu_host is not None
         logger.info(f"Reloading idpf on host side {self.config.dpu_host}")
-
         ipu_host = host.RemoteHost(self.config.dpu_host)
         ipu_host.ssh_connect("core")
         ipu_host.run("sudo rmmod idpf")

--- a/iso-surgeon/README.md
+++ b/iso-surgeon/README.md
@@ -39,6 +39,7 @@ You can optionally provide:
 * `--input_iso`: use an existing RHEL boot ISO
 * `--kickstart`: custom kickstart file
 * `--kernel_args`: GRUB arguments to inject
+* `--grub_replace`: GRUB replacements in format 'old_text:new_text' (can be used multiple times, splits on "|")
 * `--output_iso`: destination path for the new ISO
 * `--rhel_version`: the version of RHEL to generate if no input iso is given
 

--- a/isoBuilder.py
+++ b/isoBuilder.py
@@ -19,7 +19,7 @@ class BootcIsoBuilder:
         bootc_image_url: str,
         image_builder_url: str,
         dpu_flavor: str = "agnostic",
-        rhel_version: str = "9.6",
+        rhel_version: str = "9",
         input_iso: Optional[str] = None,
         kickstart: Optional[str] = None,
         kernel_args: Optional[str] = "",

--- a/isoBuilder.py
+++ b/isoBuilder.py
@@ -24,6 +24,10 @@ class BootcIsoBuilder:
         kickstart: Optional[str] = None,
         kernel_args: Optional[str] = "",
         remove_args: Optional[str] = None,
+        grub_replacements: Optional[list[str]] = None,
+        auth_file_path: Optional[str] = None,  # Allow custom auth file path
+        bootc_dir: str = "rhel-image-mode-4-dpu",
+        bootc_build_local: bool = True,
     ):
         self.h = host
         self.name_of_final_iso = name_of_final_iso
@@ -32,12 +36,17 @@ class BootcIsoBuilder:
         self.activation_key = activation_key
         self.bootc_image_url = bootc_image_url
         self.image_builder_url = image_builder_url
+        self.dpu_flavor = dpu_flavor
         self.rhel_version = rhel_version
         self.input_iso = input_iso
         self.kickstart = kickstart
         self.kernel_args = kernel_args
         self.remove_args = remove_args
-        self.dpu_flavor = dpu_flavor
+        self.grub_replacements = grub_replacements or []
+        # Use custom auth file path if provided, otherwise fallback to secrets_path for backwards compatibility
+        self.auth_file_path = auth_file_path or secrets_path
+        self.bootc_dir = bootc_dir
+        self.bootc_build_local = bootc_build_local
 
     def _add_transport_prefix(self, image: str) -> str:
         if image.startswith("containers-storage:") or image.startswith("docker://"):
@@ -52,29 +61,49 @@ class BootcIsoBuilder:
     def ensure_image_is_built(self, image_name: str, build_action: Callable[[], None]) -> None:
         """
         Ensures the image is available:
-        - Always rebuild local images (from dir or containers-storage)
-        - Always pull remote images (e.g., docker://)
-        - If pull/build fails, error out
+        - Local images (localhost/, containers-storage:, dir://): build locally, no push
+        - Docker registry images (docker://): build locally and push to registry
+        - Other remote images: try to pull from registry
         """
         is_local = image_name.startswith("containers-storage:") or image_name.startswith("dir://") or image_name.startswith("localhost/")
+        is_docker_registry = image_name.startswith("docker://")
 
         if is_local:
-            logger.info(f"Always rebuilding local image '{image_name}' for consistency.")
+            logger.info(f"Building local image '{image_name}' (no push)")
             build_action()
             return
 
+        if is_docker_registry and self.bootc_build_local:
+            # Strip docker:// prefix for podman commands
+            registry_name = image_name.replace("docker://", "")
+
+            logger.info(f"Building image locally and pushing to '{registry_name}'")
+            build_action()
+
+            # Push to the docker registry
+            logger.info(f"Pushing image to {registry_name}")
+            push_result = self.h.run(f"sudo podman push --authfile {self.auth_file_path} {registry_name}")
+            if not push_result.success():
+                logger.error_and_exit(f"Failed to push image to '{registry_name}': {push_result.err}")
+
+            logger.info(f"Successfully pushed image to {registry_name}")
+            return
+
+        # For other remote images, try to pull
         logger.info(f"Pulling remote image: {image_name}")
-        if not self.h.run(f"sudo podman pull {image_name}").success():
+        if not self.h.run(f"sudo podman pull --authfile {self.auth_file_path} {image_name}").success():
             logger.error_and_exit(f"Failed to pull remote image '{image_name}', push the container to {image_name} to build the iso here, or change transport to localhost to build a default image")
 
         if not self.h.run(f"sudo podman image exists {image_name}").success():
             logger.error_and_exit(f"Image '{image_name}' could not be pulled or built.")
 
-    def build_image_mode_container(self, image_name: str, dir: str = "rhel-image-mode-4-dpu") -> None:
+    def build_image_mode_container(self, image_name: str) -> None:
         label = "Image Mode container"
         logger.info(f"Building {label} image from local source...")
-        if not os.path.exists(dir):
-            logger.error_and_exit(f"Expected local directory at {dir}, but it does not exist.")
+        # Strip docker:// prefix for podman commands
+        image_name = image_name.replace("docker://", "")
+        if not os.path.exists(self.bootc_dir):
+            logger.error_and_exit(f"Expected local directory at {self.bootc_dir}, but it does not exist.")
 
         entitlement_cert = next((os.path.join(r, f) for r, _, fs in os.walk("/etc/pki/entitlement/") for f in fs if f.endswith(".pem") and not f.endswith("-key.pem")), None)
         entitlement_key = next((os.path.join(r, f) for r, _, fs in os.walk("/etc/pki/entitlement/") for f in fs if f.endswith("-key.pem")), None)
@@ -87,15 +116,15 @@ class BootcIsoBuilder:
         args = [
             "sudo podman build",
             "--security-opt label=type:unconfined_t",
-            f"--authfile {self.secrets_path}",
-            f"--build-arg=DPU_FLAVOR={self.dpu_flavor}",
+            f"--authfile {self.auth_file_path}",
+            f"--build-arg DPU_FLAVOR={self.dpu_flavor}",
             "--arch aarch64",
             f"--secret=id=redhat-repo,src={repo_file}",
             f"--secret=id=entitlement-cert,src={entitlement_cert}",
             f"--secret=id=entitlement-key,src={entitlement_key}",
             f"--secret=id=rhsm-ca,src={rhsm_ca}",
             f"-t {image_name}",
-            dir,
+            self.bootc_dir,
         ]
         command = " ".join(args)
 
@@ -113,7 +142,7 @@ class BootcIsoBuilder:
         if not os.path.exists(dir):
             logger.error_and_exit(f"Expected local directory at {dir}, but it does not exist.")
 
-        err, out, returncode = self.h.run(f"sudo podman build --security-opt label=type:unconfined_t " f"--authfile {self.secrets_path} --platform linux/arm64 -t {image_name} {dir}")
+        err, out, returncode = self.h.run(f"sudo podman build --security-opt label=type:unconfined_t " f"--authfile {self.auth_file_path} --platform linux/arm64 -t {image_name} {dir}")
         if returncode:
             logger.error_and_exit(f"Failed to build {label} image with error: {err}")
 
@@ -124,6 +153,8 @@ class BootcIsoBuilder:
     def generate_kickstart_image_mode(self, final_kickstart: str) -> None:
         with open(self.secrets_path, "r") as f_in:
             file_contents = f_in.read()
+        with open(self.auth_file_path, "r") as f_in:
+            ostree_auth_json = f_in.read()
 
         ssh_pub, _, _ = next(common.iterate_ssh_keys(), (None, None, None))
         if ssh_pub is not None:
@@ -138,6 +169,7 @@ class BootcIsoBuilder:
             lines = f.read()
         image_name = self.bootc_image_url
         is_local = image_name.startswith("containers-storage:") or image_name.startswith("dir://") or image_name.startswith("localhost/")
+        image_ref = self.bootc_image_url.replace("docker://", "")
 
         with open(final_kickstart, "w") as f_out:
             template = Template(lines)
@@ -149,7 +181,9 @@ class BootcIsoBuilder:
                     rhc_act_key=self.activation_key,
                     kargs=self.kernel_args,
                     is_remote=not is_local,
-                    image_ref=self.bootc_image_url,
+                    ostree_auth_json=ostree_auth_json,
+                    image_ref=image_ref,
+                    dpu_flavor=self.dpu_flavor,
                 )
             )
         if not os.path.exists(final_kickstart):
@@ -185,7 +219,7 @@ class BootcIsoBuilder:
                 "sudo podman run --rm --privileged",
                 "--security-opt label=type:unconfined_t",
                 "--arch aarch64",
-                f"-v {self.secrets_path}:/run/containers/0/auth.json:ro",
+                f"-v {self.auth_file_path}:/run/containers/0/auth.json:ro",
                 "-v /var/lib/containers:/var/lib/containers",
                 "-v /run/containers/storage:/run/containers/storage",
                 "-v /dev:/dev",
@@ -199,6 +233,9 @@ class BootcIsoBuilder:
                 args.append(f"-a '{self.kernel_args}'")
             if self.remove_args:
                 args.append(f"-r '{self.remove_args}'")
+            if self.grub_replacements:
+                for replacement in self.grub_replacements:
+                    args.append(f"-R '{replacement}'")
             if self.input_iso:
                 args.append(f"-i {self.input_iso}")
             if self.kickstart:

--- a/kickstart-image-mode.ks.j2
+++ b/kickstart-image-mode.ks.j2
@@ -11,6 +11,7 @@ network --bootproto=dhcp --device=enp0s1f0d1
 bootloader --location=mbr --driveorder=sda --append="{{ kargs }}"
 {% endif %}
 ostreecontainer --url=/run/install/repo/container --transport=oci --no-signature-verification
+reboot --eject
 %post --log=/var/log/anaconda/post-install.log --erroronfail
 
 # Add the pull secret to CRI-O and set root user-only read/write permissions
@@ -24,6 +25,7 @@ RHC_ACT_KEY={{ rhc_act_key }}
 RHC_ORG_ID={{ rhc_org_id }}
 EOF
 
+touch /etc/rhc/.run_rhc_connect_next_boot
 
 mkdir -p /home/redhat/.ssh
 cat << EOF > /home/redhat/.ssh/authorized_keys
@@ -34,7 +36,31 @@ chmod 600 /etc/crio/openshift-pull-secret
 # Configure the firewall with the mandatory rules for MicroShift
 firewall-offline-cmd --zone=trusted --add-source=10.42.0.0/16
 firewall-offline-cmd --zone=trusted --add-source=169.254.169.1
+
+cat << EOF > /etc/ostree/auth.json
+{{ ostree_auth_json }}
+EOF
+
+{% if dpu_flavor == "ipu" %}
+# Simple IPU boot fix: Just set UEFI IET VIRTUAL-DISK as first boot option
+echo "Configuring IPU boot order..." >> /var/log/anaconda/post-install.log
+ISCSI_ENTRY=$(efibootmgr | grep "IET VIRTUAL-DISK" | head -1 | sed 's/Boot\([0-9A-F]*\).*/\1/')
+if [ -n "$ISCSI_ENTRY" ]; then
+    echo "Found UEFI IET VIRTUAL-DISK entry: $ISCSI_ENTRY" >> /var/log/anaconda/post-install.log
+    # Simple approach: just set this entry as BootNext for one-time boot
+    efibootmgr -n $ISCSI_ENTRY
+    echo "Set BootNext to $ISCSI_ENTRY" >> /var/log/anaconda/post-install.log
+    efibootmgr >> /var/log/anaconda/post-install.log
+else
+    echo "ERROR: UEFI IET VIRTUAL-DISK not found" >> /var/log/anaconda/post-install.log
+    exit 1
+fi
+{% endif %}
+
 {% if is_remote %}
 bootc switch --mutate-in-place --transport registry {{ image_ref }}
 {% endif %}
+
+sync
+sleep 3
 %end

--- a/rhel-image-mode-4-dpu/Containerfile
+++ b/rhel-image-mode-4-dpu/Containerfile
@@ -1,12 +1,13 @@
-ARG DPU_FLAVOR="${DPU_FLAVOR:-agnostic}"
-ARG RHC_ACT_KEY="${RHC_ACT_KEY}"
-ARG RHC_ORG_ID="${RHC_ORG_ID}"
 ARG MAJOR_VERSION="${MAJOR_VERSION:-9}"
 ARG MINOR_VERSION="${MINOR_VERSION:-6}"
+
 
 FROM registry.redhat.io/rhel${MAJOR_VERSION}/rhel-bootc:${MAJOR_VERSION}.${MINOR_VERSION}
 # 1. Add all extra repos in one g# Will mount redhat.repo from a secret instead
 
+# Re-declare ARG after FROM to make build-arg available, then set ENV
+ARG DPU_FLAVOR=agnostic
+ENV DPU_FLAVOR=${DPU_FLAVOR}
 RUN distro=$(sed -n 's/^distroverpkg=//p' /etc/yum.conf) && \
     source /etc/os-release && \
     releasever="$VERSION_ID" && \
@@ -52,29 +53,46 @@ RUN --mount=type=secret,id=redhat-repo \
         -e "s|sslclientkey *=.*|sslclientkey=/run/secrets/entitlement-key|" \
         /run/secrets/redhat-repo > /etc/yum.repos.d/redhat.repo 
 
-# 2. Consolidated all package installs into one layer,
-#    with conditional bits for IPU flavor.
+# After setting up all repositories, add this layer to cache repo metadata
+RUN --mount=type=secret,id=entitlement-cert \
+    --mount=type=secret,id=entitlement-key \
+    --mount=type=secret,id=rhsm-ca \
+    dnf makecache --refresh && \
+    dnf repolist
+
+# 2. Consolidated all package installs into one layer
 RUN --mount=type=secret,id=entitlement-cert \
     --mount=type=secret,id=entitlement-key \
     --mount=type=secret,id=rhsm-ca \
     dnf install -y --allowerasing \
       rhc rhc-worker-playbook \
       git \
+      go-toolset \
       dhcp-client \
       microshift microshift-multus \
-      make firewalld jq gcc glibc-devel \
-      && if [ "$DPU_FLAVOR" = "ipu" ]; then \
-           dnf install -y iscsi-initiator-utils && \
-           mkdir -p /usr/lib/bootc/kargs.d && \
-           printf 'kargs = ["ip=192.168.0.2:::255.255.255.0::enp0s1f0:off","netroot=iscsi:192.168.0.1::::iqn.e2000:acc","acpi=force"]\n' \
-             > /usr/lib/bootc/kargs.d/00-network.toml && \
-           printf 'dracutmodules+=" iscsi network "' \
-             >> /usr/lib/dracut/dracut.conf.d/50-custom-added-modules.conf && \
-           kver=$(cd /usr/lib/modules && echo *) && \
-           dracut -vf "/usr/lib/modules/$kver/initramfs.img" "$kver"; \
-        fi \
-      && dnf clean all && \
-      rm -rf /etc/yum.repos.d/redhat.repo
+      make firewalld jq gcc glibc-devel 
+
+COPY hugepages-setup.service /tmp/hugepages-setup.service
+
+RUN --mount=type=secret,id=entitlement-cert \
+    --mount=type=secret,id=entitlement-key \
+    --mount=type=secret,id=rhsm-ca \
+    if [ "$DPU_FLAVOR" = "ipu" ]; then \
+             echo "Installing ipu" && \
+             dnf install -y iscsi-initiator-utils && \
+             mkdir -p /usr/lib/bootc/kargs.d && \
+             printf 'kargs = ["ip=192.168.0.2:::255.255.255.0::enp0s1f0:off","netroot=iscsi:192.168.0.1::::iqn.e2000:acc","acpi=force"]\n' \
+               > /usr/lib/bootc/kargs.d/00-network.toml && \
+             printf 'dracutmodules+=" iscsi network "' \
+               >> /usr/lib/dracut/dracut.conf.d/50-custom-added-modules.conf && \
+             mkdir -p /etc/iscsi && \
+             printf 'node.startup = automatic\nnode.conn[0].timeo.noop_out_interval = 5\nnode.conn[0].timeo.noop_out_timeout = 10\nnode.session.timeo.replacement_timeout = 120\nnode.session.err_timeo.abort_timeout = 15\nnode.session.err_timeo.lu_reset_timeout = 30\nnode.session.err_timeo.tgt_reset_timeout = 30\nnode.session.initial_login_retry_max = 8\n' \
+               > /etc/iscsi/iscsid.conf && \
+             sed -i 's/thin_pool_autoextend_threshold = 100/thin_pool_autoextend_threshold = 80/' /etc/lvm/lvm.conf && \
+             kver=$(cd /usr/lib/modules && echo *) && \
+             dracut -vf "/usr/lib/modules/$kver/initramfs.img" "$kver"; \
+          fi
+
 
 
 # 3. Enable services in one go
@@ -101,6 +119,9 @@ ExecStop=/bin/rm -f /etc/rhc/.rhc_connect_credentials
 [Install]
 WantedBy=multi-user.target
 EOF
+
+# Create symlink for VSP P4 directories to work on OSTree
+RUN mkdir -p /var/p4 && ln -sf /var/p4 /opt/p4
 # 4. Tweak MicroShift service and OVS drop-in
 RUN mkdir -p /etc/systemd/system/microshift.service.d && \
     cat > /etc/systemd/system/microshift.service.d/override.conf <<EOF
@@ -127,14 +148,15 @@ ExecStartPre=/bin/sh -c '/bin/getent group hugetlbfs >/dev/null || groupadd -r h
 ExecStartPre=/sbin/usermod -a -G hugetlbfs openvswitch
 ExecStartPre=/bin/chown -Rhv openvswitch. /etc/openvswitch
 EOF
-RUN systemctl enable rhc-connect microshift microshift-make-rshared.service
-
-
-# 5. Install Go and user setup in one layer
-RUN curl -LO https://go.dev/dl/go1.22.6.linux-arm64.tar.gz && \
-    tar -C /usr/local -xzf go1.22.6.linux-arm64.tar.gz && \
-    rm go1.22.6.linux-arm64.tar.gz && \
-    echo "export PATH=\$PATH:/usr/local/go/bin" >> /etc/profile 
+RUN systemctl enable rhc-connect microshift microshift-make-rshared.service && \
+    if [ "$DPU_FLAVOR" = "ipu" ]; then \
+     cp /tmp/hugepages-setup.service /etc/systemd/system/hugepages-setup.service && \
+        systemctl enable hugepages-setup.service && \
+        systemctl enable iscsid iscsi && \
+        mkdir -p /etc/systemd/system/iscsid.service.d && \
+        printf '[Unit]\nDefaultDependencies=no\nConflicts=shutdown.target\nBefore=shutdown.target umount.target\n\n[Service]\nKillMode=none\nTimeoutStopSec=30\n' \
+          > /etc/systemd/system/iscsid.service.d/shutdown-fix.conf; \
+    fi
 
 RUN useradd -m -p '$6$DYgjv/BVpdq/0EVt$2fd9RPHleTgsFWzTLL/I.znl9vbKgt00eXQ0LNbkc7wBF67fSYBsZd6LutDZHI0YZNg3SKB04SdpLOkuWRzni.' -G wheel redhat && \
     echo -e 'redhat\tALL=(ALL)\tNOPASSWD: ALL' >> /etc/sudoers && \
@@ -142,3 +164,14 @@ RUN useradd -m -p '$6$DYgjv/BVpdq/0EVt$2fd9RPHleTgsFWzTLL/I.znl9vbKgt00eXQ0LNbkc
     echo 'u redhat 1000 "Red Hat User" /home/redhat /bin/bash' > /usr/lib/sysusers.d/redhat.conf && \
     echo 'g redhat 1000' >> /usr/lib/sysusers.d/redhat.conf && \
     echo 'g hugetlbfs 999' > /usr/lib/sysusers.d/hugetlbfs.conf
+
+# Configure SSH to permit root login
+RUN mkdir -p /etc/ssh/sshd_config.d && \
+    echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/99-permit-root-login.conf
+
+RUN systemctl disable firewalld && systemctl enable sshd && systemctl disable NetworkManager-wait-online.service
+
+RUN --mount=type=secret,id=entitlement-cert \
+    --mount=type=secret,id=entitlement-key \
+    --mount=type=secret,id=rhsm-ca \
+     dnf clean all

--- a/rhel-image-mode-4-dpu/hugepages-setup.service
+++ b/rhel-image-mode-4-dpu/hugepages-setup.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Setup Hugepages for P4 containers
+Before=microshift.service
+Wants=microshift.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/bin/mkdir -p /dev/hugepages
+ExecStart=/bin/mount -t hugetlbfs -o pagesize=2M none /dev/hugepages
+ExecStart=/bin/sh -c 'echo 512 > /sys/devices/system/node/node0/hugepages/hugepages-2048kB/nr_hugepages'
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This PR brings in all changes needed to fully build, provision and deploy the dpu operator on RHEL Image Mode.
It makes the microshift extra config more idempotent since many parts of the post step is already part of the image and fixes some parts of iso builder to allow for full automation. It also now uses Centos Stream boot iso the base for ISO Surgeon which means now any vendor should be able to bake their own ISO's on x86 targeting arm64 (Tested on IPU's for now). To use it I generally make a iso-builder.yaml like below and run it with `-s pre`:
Note: Does not really require a dpu apart for detecting the flavour of the dpu and could be used with a non dpu server after a few tweaks

```bash
clusters:
  - name: "microshift"
    api_vip: "192.168.122.99"
    ingress_vip: "192.168.122.101"
    network_api_port: "eno12409"
    kind: "iso"
    install_iso: "" # leaving it empty makes uses the default iso filename
    # install_iso: "./RHEL-DPU-CUSTOM-LATEST-20250730-aarch64.iso"
    kubeconfig: "/root/kubeconfig.microshift"
    masters:
      - name: "215-acc"
        node: "localhost"
        kind: "dpu"
        bmc:
          url: "wsfd-advnetlab215-intel-ipu-imc.anl.eng.bos2.dc.redhat.com"
        bmc_host:
          user: "root"
          password: "calvin"
          url: "wsfd-advnetlab215-drac.anl.eng.bos2.dc.redhat.com"
        dpu_host: "wsfd-advnetlab215.anl.eng.bos2.dc.redhat.com"
        ip: "172.16.3.16"
        mac: "10:2e:00:01:b1:f2"
    preconfig:
      - name: host_registries # formats the registry credentials in the authfile format, by default merges your cluster pull secret for access to registry.redhat.io
        registries:
          - registry_url: "quay.io"
            user: "sadasilv+ipu_kickstart"
            token: "REDACTED"
            auth_path: "/tmp/auth.json"
      - name: iso_builder
        organization_id: "REDACTED"
        activation_key: "REDACTED"
        iso_builder_auth_file: "/tmp/auth.json" # Uses the auth for private registry access and building
        image_mode_url: "docker://quay.io/sadasilv/rhel-image-mode-4-dpu:latest" # will build from current image mode dir and push to destination
```