### PR TITLE
adjust redfish workaround

### DIFF
--- a/ipu.py
+++ b/ipu.py
@@ -219,7 +219,8 @@ class IPUBMC(BMC):
 logger "Activating redfish"
 cp /work/redfish/certs/server.key /etc/pki/ca-trust/source/anchors/
 cp /work/redfish/certs/server.crt /etc/pki/ca-trust/source/anchors/
-/usr/bin/scripts/set_acc_kernel_cmdline.sh -a -b custom
+/usr/bin/scripts/set_acc_kernel_cmdline.sh -a -b iscsi
+sync
 update-ca-trust
 systemctl restart redfish
 """


### PR DESCRIPTION
Redfish team initially gave guidance to use the word "custom", but due to some apparent corner cases where "custom" showed up in redfish logs for hard failures, we will now go with "iscsi" which is the initial condition of this parameter after a stock install.

Validated by CI#1773 for PR507 in dpu-operator