### PR TITLE
[th/marvell-boot-live-iso] marvell: boot live ISO for accessing worker node

### DIFF
--- a/coreosBuilder.py
+++ b/coreosBuilder.py
@@ -81,6 +81,8 @@ class CoreosBuilder:
         self._clone_if_not_exists("https://github.com/coreos/coreos-assembler.git")
         config_dir = self._clone_if_not_exists("https://github.com/coreos/fedora-coreos-config")
 
+        lh.run(f"git -C {config_dir} submodule update --init --recursive")
+
         contents = "packages:\n  - kernel-modules-extra\n"
         # contents = contents + "  - python3\n  - libvirt\n  - qemu-img\n  - qemu-kvm\n  - virt-install\n  - netcat\n  - bridge-utils\n  - tcpdump\n"
 

--- a/dpuVendor.py
+++ b/dpuVendor.py
@@ -1,5 +1,6 @@
 import re
 import host
+import typing
 from logger import logger
 from abc import ABC, abstractmethod
 import ipu
@@ -7,14 +8,18 @@ import marvell
 import clustersConfig
 
 
-def detect_dpu(node: clustersConfig.NodeConfig) -> str:
+def detect_dpu(
+    node: clustersConfig.NodeConfig,
+    *,
+    get_external_port: typing.Callable[[], str],
+) -> str:
     logger.info("Detecting DPU")
     assert node.kind == "dpu"
     assert node.bmc is not None
     ipu_bmc = ipu.IPUBMC(node.bmc)
     if ipu_bmc.is_ipu():
         return "ipu"
-    elif marvell.is_marvell(node.bmc):
+    elif marvell.is_marvell(node.bmc, bmc_host=node.bmc_host, get_external_port=get_external_port):
         return "marvell"
     else:
         logger.error_and_exit("Unknown DPU")

--- a/extraConfigDpu.py
+++ b/extraConfigDpu.py
@@ -141,7 +141,7 @@ def ExtraConfigDpu(cc: ClustersConfig, cfg: ExtraConfigArgs, futures: dict[str, 
     acc.run("systemctl stop firewalld")
     acc.run("systemctl disable firewalld")
 
-    vendor_plugin = init_vendor_plugin(acc, detect_dpu(dpu_node))
+    vendor_plugin = init_vendor_plugin(acc, detect_dpu(dpu_node, get_external_port=cc.get_external_port))
     # TODO: For Intel, this configures hugepages. Figure out a better way
     vendor_plugin.setup(acc)
 

--- a/extraConfigIsoBuilder.py
+++ b/extraConfigIsoBuilder.py
@@ -48,7 +48,7 @@ def ExtraConfigIsoBuilder(
     if len(cc.masters) < 1:
         logger.error_and_exit("Error: At least one master is needed for the OS environment to match the DPU requirements")
     node = cc.masters[0]
-    dpu_flavor = detect_dpu(node) if node.kind == "dpu" else "agnostic"
+    dpu_flavor = detect_dpu(node, get_external_port=cc.get_external_port) if node.kind == "dpu" else "agnostic"
     if dpu_flavor == "ipu":
         extra_args = " ip=192.168.0.2:::255.255.255.0::enp0s1f0:off netroot=iscsi:192.168.0.1::::iqn.e2000:acc acpi=force"
         kernel_args = (kernel_args or "") + extra_args

--- a/isoDeployer.py
+++ b/isoDeployer.py
@@ -70,7 +70,7 @@ class IsoDeployer(BaseDeployer):
         self._setup_networking()
         assert self._master.kind == "dpu"
         assert self._master.bmc is not None
-        dpu_kind = detect_dpu(self._master)
+        dpu_kind = detect_dpu(self._master, get_external_port=self._cc.get_external_port)
         if dpu_kind == "ipu":
             node = ipu.IPUClusterNode(self._master, self._cc.get_external_port(), self._cc.network_api_port)
             node.start(self._cc.install_iso)

--- a/marvell.py
+++ b/marvell.py
@@ -1,12 +1,22 @@
 import os
 import shlex
+import typing
 from clustersConfig import NodeConfig
+from bmc import BMC
 from bmc import BmcConfig
 import common
 import host
+from logger import logger
+import coreosBuilder
+from nfs import NFS
 
 
-def marvell_bmc_rsh(bmc: BmcConfig) -> host.Host:
+def marvell_bmc_rsh(
+    bmc: BmcConfig,
+    *,
+    bmc_host: typing.Optional[BmcConfig] = None,
+    get_external_port: typing.Optional[typing.Callable[[], str]] = None,
+) -> typing.Optional[host.Host]:
     # For Marvell DPU, we require that our "BMC" is the host on has the DPU
     # plugged in.
     #
@@ -20,17 +30,53 @@ def marvell_bmc_rsh(bmc: BmcConfig) -> host.Host:
     # same time (e.g. via Jinja2 templates), we can start honoring
     # bmc.user/bmc.password.
     rsh = host.RemoteHost(bmc.url)
-    rsh.ssh_connect("core")
+
+    try:
+        rsh.ssh_connect("core", timeout="2m")
+    except Exception as e:
+        logger.info(f"Cannot connect to core @ {bmc.url}: {e}")
+    else:
+        return rsh
+
+    if bmc_host is None:
+        return None
+
+    assert get_external_port
+
+    logger.info(f"For Marvell host {bmc.url} boot CoreOS Live via BMC {bmc_host.url}")
+
+    coreosBuilder.ensure_fcos_exists()
+    lh = host.LocalHost()
+    nfs = NFS(lh, get_external_port())
+    iso_url = nfs.host_file("/root/iso/fedora-coreos.iso")
+
+    BMC.from_bmc_config(bmc_host).boot_iso_redfish(iso_url)
+
+    rsh.ssh_connect("core", timeout="15m")
     return rsh
 
 
-def is_marvell(bmc: BmcConfig) -> bool:
-    rsh = marvell_bmc_rsh(bmc)
+def is_marvell(
+    bmc: BmcConfig,
+    *,
+    bmc_host: typing.Optional[BmcConfig] = None,
+    get_external_port: typing.Optional[typing.Callable[[], str]] = None,
+) -> bool:
+    rsh = marvell_bmc_rsh(
+        bmc,
+        bmc_host=bmc_host,
+        get_external_port=get_external_port,
+    )
+    if rsh is None:
+        return False
     return "177d:b900" in rsh.run("lspci -nn -d :b900").out
 
 
 def _pxeboot_marvell_dpu(name: str, bmc: BmcConfig, mac: str, ip: str, iso: str) -> None:
     rsh = marvell_bmc_rsh(bmc)
+
+    if rsh is None:
+        raise RuntimeError(f"Cannot connect to {bmc.url} for pxeboot of Marvell DPU")
 
     ip_addr = f"{ip}/24"
     ip_gateway = common.ip_to_gateway(ip, "255.255.255.0")

--- a/marvell.py
+++ b/marvell.py
@@ -90,6 +90,8 @@ def _pxeboot_marvell_dpu(name: str, bmc: BmcConfig, mac: str, ip: str, iso: str)
 
     image = os.environ.get("CDA_MARVELL_TOOLS_IMAGE", "quay.io/sdaniele/marvell-tools:latest")
 
+    logger.info(f"run pxeboot via {image}")
+
     r = rsh.run(
         "set -o pipefail ; "
         "sudo "


### PR DESCRIPTION

We use pxeboot to install RHEL on the DPU. For that, we need to SSH into
the host (that has the DPU inside) and run a podman command. That
requires that the host is up and accessible via SSH.

Also, CDA is not told by configuration which kind of DPU the host has
inside. Instead, to detect that it should install a Marvell DPU, it
needs to SSH into the host and check lspci.

If the host is not accessible, then previously installation would fail.

Well, the intended approach would have been to install the OCP cluster
(including the worker) first. Then the worker node would be accessible
via SSH, and all would be good. However, that is not done.

Hence, if the machine is not accessible, fallback to boot a CoreOS Live
iso.

https://issues.redhat.com/browse/MDC-108
https://issues.redhat.com/browse/IIC-806
