### PR TITLE
[th/revert-test-patch] Revert "test/marvell: simular host unreachable for testing boot coreos"

### DIFF
--- a/marvell.py
+++ b/marvell.py
@@ -44,10 +44,6 @@ class MarvellBMC:
         rsh = host.RemoteHost(self.bmc.url)
 
         try:
-            if boot_coreos:
-                # FIXME: testing only. Drop this part.
-                raise RuntimeError("TEST: for testing simulate host is unrechable and boot coreos")
-
             rsh.ssh_connect("core", timeout="2m")
         except Exception as e:
             logger.info(f"Cannot connect to core @ {self.bmc.url}: {e}")


### PR DESCRIPTION
This was always just intended as a means to trigger the behavior in CI. The patch was intended to be only there during review, it should not have been merged.

Revert again.

This reverts commit 504f01da7766d6f221bb71157fad79f273e83c8e.