### PR TITLE
ipu: don't crash during IPUBMC.ensure_started()

### DIFF
--- a/ipu.py
+++ b/ipu.py
@@ -350,9 +350,9 @@ fi
         with open(__file__) as f:
             return sha("".join(f.readlines()))
 
-    def _create_imc_rsh(self) -> host.Host:
+    def _create_imc_rsh(self, *, timeout: str = "15m") -> host.Host:
         rsh = host.RemoteHost(self.bmc_host)
-        rsh.ssh_connect("root", password="", discover_auth=False)
+        rsh.ssh_connect("root", password="", discover_auth=False, timeout=timeout)
         return rsh
 
     @staticmethod
@@ -506,7 +506,10 @@ fi
 
     def ensure_started(self) -> None:
         self._host_bmc.ensure_started()
-        self._create_imc_rsh().wait_ping()
+        try:
+            self._create_imc_rsh(timeout="5m")
+        except Exception:
+            return
 
     def cold_boot(self) -> None:
         assert self._host_bmc is not None


### PR DESCRIPTION
IPUBMC.ensure_started() called

    self._create_imc_rsh().wait_ping()

But _create_imc_rsh() tries to SSH into the host, with a timeout of one hour. On failure (and after one hour), it fails with an exception that was not expected by the caller and lead to a crash.

Instead, use a timeout of "only" 5 minutes, and hide the exception. There is no need for Host.wait_ping(), because Host.ssh_connect() already does a ping internally.

This works around the most glaring problems with this. On Marvell cluster, the "is_ipu()" check would wait to start the machine, which then fails to be accessible via SSH. More patches will follow to solve this better.