### PR TITLE
[th/jinja-set-globals] clustersConfig: use jinja2.Environment to workaround typing issue

### DIFF
--- a/clustersConfig.py
+++ b/clustersConfig.py
@@ -517,23 +517,24 @@ class ClustersConfig:
             assert self._cluster_info is not None
             return self._cluster_info.dpu_mac_addresses[a]
 
-        format_string = contents
+        env = jinja2.Environment()
 
-        template = jinja2.Template(format_string)
-        template.globals['worker_number'] = worker_number
-        template.globals['worker_name'] = worker_name
-        template.globals['primary_network_port'] = primary_network_port
-        template.globals['api_network'] = primary_network_port
-        template.globals['secondary_network_port'] = secondary_network_port
-        template.globals['iso_server'] = iso_server
-        template.globals['bmc'] = bmc
-        template.globals['activation_key'] = activation_key
-        template.globals['organization_id'] = organization_id
-        template.globals['bmc_hostname'] = bmc_hostname
-        template.globals['DPU_mac_address'] = dpu_mac_address
+        env.globals['worker_number'] = worker_number
+        env.globals['worker_name'] = worker_name
+        env.globals['primary_network_port'] = primary_network_port
+        env.globals['api_network'] = primary_network_port
+        env.globals['secondary_network_port'] = secondary_network_port
+        env.globals['iso_server'] = iso_server
+        env.globals['bmc'] = bmc
+        env.globals['activation_key'] = activation_key
+        env.globals['organization_id'] = organization_id
+        env.globals['bmc_hostname'] = bmc_hostname
+        env.globals['DPU_mac_address'] = dpu_mac_address
 
         kwargs = {}
         kwargs["cluster_name"] = cluster_name
+
+        template = env.from_string(contents)
 
         t: str = template.render(**kwargs)
         return t


### PR DESCRIPTION
On github CI, this code passes the linter check without warning. But for some unclear reason, on my system I get a mypy error:

    64 files left unchanged.
    clustersConfig.py:523: error: "Template" has no attribute "globals"  [attr-defined]
    clustersConfig.py:524: error: "Template" has no attribute "globals"  [attr-defined]
    clustersConfig.py:525: error: "Template" has no attribute "globals"  [attr-defined]
    clustersConfig.py:526: error: "Template" has no attribute "globals"  [attr-defined]
    clustersConfig.py:527: error: "Template" has no attribute "globals"  [attr-defined]
    clustersConfig.py:528: error: "Template" has no attribute "globals"  [attr-defined]
    clustersConfig.py:529: error: "Template" has no attribute "globals"  [attr-defined]
    clustersConfig.py:530: error: "Template" has no attribute "globals"  [attr-defined]
    clustersConfig.py:531: error: "Template" has no attribute "globals"  [attr-defined]
    clustersConfig.py:532: error: "Template" has no attribute "globals"  [attr-defined]
    clustersConfig.py:533: error: "Template" has no attribute "globals"  [attr-defined]
    Found 11 errors in 1 file (checked 64 source files)

Mypy is partly correct. The more correct way of using the API is to create an environment, set the globals there, and create the template from the environment.

Do that.

This also allows me to run mypy on my machine.