### PR TITLE
Fix microshift install failure due to rpm-ostree/bootc file conflict

### DIFF
--- a/extraConfigMicroshift.py
+++ b/extraConfigMicroshift.py
@@ -112,6 +112,9 @@ def ExtraConfigMicroshift(cc: ClustersConfig, cfg: ExtraConfigArgs, futures: dic
     logger.info(f"ACC date: {acc_date}")
 
     logger.info("Installing microshift")
+    # Remove pre-installed bootc to avoid file conflicts with rpm-ostree (RHEL-144611).
+    # Both packages ship files under /usr/libexec/libostree/ext/ starting with bootc >= 1.12.
+    acc.run("rpm -e --nodeps bootc 2>/dev/null || true")
     acc.run_or_die("dnf install -y microshift microshift-multus", retry=60)
     ret = acc.run(r"grep '\[crio.runtime.runtimes.crun\]' /etc/crio/crio.conf")
     if not ret.success():


### PR DESCRIPTION
## Summary

- Remove pre-installed `bootc` before `dnf install` for microshift to resolve file conflicts with `rpm-ostree`
- The conflicting files under `/usr/libexec/libostree/ext/` (`ostree-container`, `ostree-ima-sign`, `ostree-provisional-repair`) are owned by both `bootc >= 1.12` and `rpm-ostree`
- This is a known RHEL packaging issue ([RHEL-144611](https://issues.redhat.com/browse/RHEL-144611))

## Problem

The DPU E2E deployment pipeline (`99_E2E_Marvell_DPU_Deploy`) fails during microshift installation on the ACC when `bootc >= 1.12` is pre-installed:

```
Error: Transaction test error:
  file /usr/libexec/libostree/ext/ostree-container from install of
    rpm-ostree-2025.6-6.el9_6.aarch64 conflicts with file from package bootc-1.12.1-1.el9.aarch64
```

The install retries 60 times and then aborts the entire deployment.

## Why not `--allowerasing`?

`--allowerasing` was initially considered but **does not fix file-level conflicts** — it only resolves dependency-level conflicts (allowing dnf to erase packages that block dependency resolution). File ownership conflicts between unrelated packages are a different error path in the dnf transaction test.

**Verified on RHEL 9.6 aarch64** (`01-arm-ff61-u2.anl.eng.rdu2.dc.redhat.com`):
- Reproduced the exact RHEL-144611 error with `bootc-1.12.1-1.el9` + `rpm-ostree-2025.6-6.el9_6`
- Confirmed `--allowerasing` still produces the same file conflict error
- Confirmed `rpm -e --nodeps bootc` before `dnf install microshift` resolves the issue
- After microshift install, dnf pulls in `bootc-1.1.6` (from RHEL repos) which does not ship the conflicting files

## Fix

Remove bootc before installing microshift: `rpm -e --nodeps bootc 2>/dev/null || true`. This is safe because:
1. If bootc is not installed, the command is a no-op
2. If bootc is installed (>= 1.12), removing it avoids the file conflict
3. dnf reinstalls `bootc-1.1.6` (non-conflicting version) as a dependency of microshift

## Test plan

- [ ] Run DPU E2E deployment pipeline with RHEL 9.6 ISO on ACC with pre-installed bootc >= 1.12
- [ ] Verify microshift installs successfully on the ACC
- [ ] Verify microshift starts and cluster becomes ready
- [ ] Verify bootc is reinstalled (non-conflicting version) after microshift install

## References

- Jenkins failure: [Build #18047](https://jenkins-csb-nst-net-hw-ci.dno.corp.redhat.com/job/99_E2E_Marvell_DPU_Deploy/18047/console)
- RHEL bug: [RHEL-144611](https://issues.redhat.com/browse/RHEL-144611)
- NHE tracking: [NHE-2282](https://issues.redhat.com/browse/NHE-2282)