### PR TITLE
Fix ovnkube-node stuck in ContainerCreating due to stale CRI-O sandbox reservation

### DIFF
--- a/extraConfigMicroshift.py
+++ b/extraConfigMicroshift.py
@@ -66,6 +66,22 @@ def masquarade(rsh: host.Host, cc: ClustersConfig) -> None:
     rsh.run_or_die(f"{ip_tables} -A FORWARD -i {lan_interface} -o {wan_interface} -j ACCEPT")
 
 
+def fix_stale_ovnkube_node(acc: host.Host) -> None:
+    kubeconfig = "/var/lib/microshift/resources/kubeadmin/kubeconfig"
+    ret = acc.run(f"KUBECONFIG={kubeconfig} kubectl -n openshift-ovn-kubernetes get pod -l app=ovnkube-node --no-headers 2>/dev/null")
+    if "ContainerCreating" not in ret.out:
+        return
+    # ovnkube-node is stuck due to a stale CRI-O sandbox name reservation.
+    # Restarting CRI-O clears the reservation; force-deleting the pod lets kubelet recreate it.
+    logger.info("ovnkube-node stuck in ContainerCreating — restarting CRI-O to clear stale sandbox reservation")
+    acc.run_or_die("systemctl restart crio")
+    time.sleep(15)
+    pod_name = acc.run(f"KUBECONFIG={kubeconfig} kubectl -n openshift-ovn-kubernetes get pod -l app=ovnkube-node -o name --no-headers 2>/dev/null").out.strip()
+    if pod_name:
+        acc.run(f"KUBECONFIG={kubeconfig} kubectl -n openshift-ovn-kubernetes delete {pod_name} --grace-period=0 --force 2>/dev/null")
+        logger.info(f"Force-deleted {pod_name} — ovn-controller will restart and unblock ovnkube-master")
+
+
 def ExtraConfigMicroshift(cc: ClustersConfig, cfg: ExtraConfigArgs, futures: dict[str, Future[Optional[host.Result]]]) -> None:
     [f.result() for (_, f) in futures.items()]
     logger.info("Running post config step to start Microshift on the IPU")
@@ -135,6 +151,10 @@ def ExtraConfigMicroshift(cc: ClustersConfig, cfg: ExtraConfigArgs, futures: dic
 
     acc.run("systemctl stop firewalld")
     acc.run("systemctl disable firewalld")
+
+    logger.info("Waiting 2 minutes for microshift to stabilize before checking OVN pods")
+    time.sleep(120)
+    fix_stale_ovnkube_node(acc)
 
     def cb() -> None:
         acc.run("ip r del default via 192.168.0.1")


### PR DESCRIPTION
## Problem

After microshift starts, `ovnkube-node` can get stuck indefinitely in `ContainerCreating` with a CRI-O `name is reserved` error for the sandbox. This creates a deadlock:

1. `ovnkube-node` is stuck → `ovn-controller` never starts → no `ovn-controller.pid`
2. `ovnkube-master` crashes in CrashLoopBackOff waiting for `ovn-controller.pid`
3. No CNI config written → node stays `NotReady` forever
4. CI job hits the 8-hour timeout

This was observed in the DPU E2E pipeline (`pull-ci-openshift-dpu-operator-main-make-e2e-test-marvell`).

## Fix

Add `fix_stale_ovnkube_node()` which runs 2 minutes after microshift starts and:
1. Checks if `ovnkube-node` is stuck in `ContainerCreating`
2. If so, restarts CRI-O (clears the stale sandbox name reservation)
3. Force-deletes the stuck pod so kubelet recreates it cleanly

If the condition is not present, the function is a no-op.

The root cause (stale CRI-O sandbox name reservation) is a known CRI-O issue that occurs when a previous pod sandbox was not fully cleaned up.