### PR TITLE
clusterNode: clean up stale systemd-machined entries after virsh undefine and before virsh start

### DIFF
--- a/clusterNode.py
+++ b/clusterNode.py
@@ -166,6 +166,21 @@ class VmClusterNode(ClusterNode):
     def has_booted(self) -> bool:
         return self.hostconn.vm_is_running(self.config.name)
 
+    def _cleanup_machined_entries(self) -> None:
+        # virsh destroy/undefine leaves orphaned systemd-machined scope units
+        # (qemu-N-<name> entries in /run/systemd/machines/) that survive across
+        # runs and cause "MachineExists" errors on the next virsh start.
+        name = self.config.name
+        r = self.hostconn.run("machinectl list --no-legend 2>/dev/null")
+        if r.returncode != 0:
+            return
+        for line in r.out.splitlines():
+            parts = line.split()
+            if parts and name in parts[0]:
+                machine = parts[0]
+                logger.info(f"Cleaning up stale machined entry: {machine}")
+                self.hostconn.run(f"machinectl terminate {machine}")
+
     def teardown(self) -> None:
         # remove the image only if it really exists
         image_path = self.config.image_path
@@ -178,6 +193,7 @@ class VmClusterNode(ClusterNode):
             logger.info(r.err if r.err else r.out.strip())
             r = self.hostconn.run(f"virsh undefine {self.config.name}")
             logger.info(r.err if r.err else r.out.strip())
+            self._cleanup_machined_entries()
 
     def ensure_reboot(self) -> bool:
         def vm_state(h: host.Host, node_name: str, running: bool) -> bool:
@@ -192,6 +208,7 @@ class VmClusterNode(ClusterNode):
         if not self.hostconn.vm_is_running(name):
             # VM is not running, so we need to start it manually
             logger.info(f"VM {name} is not running after reboot, starting it manually")
+            self._cleanup_machined_entries()
             r = self.hostconn.run(f"virsh start {name}")
             if not r.success():
                 # Check if it failed because domain is already active (race condition)


### PR DESCRIPTION
## Problem

`virsh destroy` + `virsh undefine` removes the libvirt domain but leaves behind orphaned systemd-machined scope units (`qemu-N-<name>` entries in `/run/systemd/machines/`). These persist across CI runs and cause the next run to fail when libvirt assigns the same QEMU slot ID:

```
GDBus.Error:org.freedesktop.machine1.MachineExists:
Machine 'qemu-5-ocpcluster-master-3' already exists
```

This has caused multiple consecutive Jenkins CI failures (`99_E2E_Marvell_DPU_Deploy` jobs #18114, #18123, #18124) requiring manual intervention to clean up the stale entries between runs.

## Root Cause

When a VM is started by QEMU/libvirt, systemd-machined registers a scope unit named `qemu-<ID>-<domainname>`. When the VM is stopped cleanly, machined deregisters it. But when libvirt forcefully destroys/undefines a VM (as CDA does during teardown), the machined scope unit is left behind as an orphan in `/run/systemd/machines/`. On the next run, libvirt assigns the same QEMU slot ID (since it picks the lowest available), and machined rejects the registration.

The same issue occurs in `ensure_reboot()` when `virsh start` is called manually after a VM fails to auto-restart post-installation reboot: stale entries from a previous aborted run block the start.

## Fix

Add `_cleanup_machined_entries()` which scans `machinectl list` for any registered machines matching the domain name and terminates them. Call it:
- In `teardown()` after `virsh undefine` — prevents entries from accumulating
- In `ensure_reboot()` before `virsh start` — safety net for entries left by previously aborted runs

## Testing

Verified manually on wsfd-advnetlab44 (the Marvell DPU CI hypervisor) that `machinectl terminate` correctly removes stale entries and subsequent `virsh start` succeeds without MachineExists errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)