### PR TITLE
virtualBridge: Redeploy the default network when it's not active.

### DIFF
--- a/configLoader.py
+++ b/configLoader.py
@@ -13,8 +13,8 @@ class LineNumberLoader(yaml.SafeLoader):
     def construct_mapping(self, node: MappingNode, deep: bool = False) -> Any:
         mapping = {}
         for key_node, value_node in node.value:
-            key = self.construct_object(key_node, deep=deep)  # type: ignore
-            value = self.construct_object(value_node, deep=deep)  # type: ignore
+            key = self.construct_object(key_node, deep=deep)
+            value = self.construct_object(value_node, deep=deep)
             mapping[key] = value
             if isinstance(key_node, ScalarNode):
                 mapping[f"_line_{key}"] = key_node.start_mark.line

--- a/virtualBridge.py
+++ b/virtualBridge.py
@@ -192,6 +192,11 @@ class VirBridge:
             logger.info("Bridge needs to be reconfigured: unexpected bridge IP")
             needs_reconfigure = True
 
+        active_ret = self.hostconn.run("virsh net-info default | grep Active")
+        if "no" in active_ret.out:
+            logger.info("Bridge needs to be reconfigured: the default network is down")
+            needs_reconfigure = True
+
         if needs_reconfigure:
             logger.info("Destoying and recreating bridge")
             logger.info(f"creating default-net.xml on {hostname}")


### PR DESCRIPTION
The default network might not come up after reboot because the IP is already taken by the bridge. Make sure we redeploy the network if that's the case.