### PR TITLE
ovn: Add extra RPM build option.

### DIFF
--- a/manifests/ovn/Dockerfile
+++ b/manifests/ovn/Dockerfile
@@ -28,7 +28,8 @@ WORKDIR /root/ovn/ovs
 RUN ./boot.sh && ./configure && make dist
 
 WORKDIR /root/ovn
-RUN ./boot.sh && ./configure && make dist && make rpm-fedora
+RUN ./boot.sh && ./configure && make dist && \
+     make rpm-fedora RPMBUILD_OPT="--without check --without sphinx"
 
 FROM $OVNK_IMAGE
 


### PR DESCRIPTION
Add extra --without sphinx option to RPM build of OVN. The --without check is added for backward compatibility as it's the default value of RPMBUILD_OPT when there isn't any value specified.