### PR TITLE
Networking fixes and enhancements

### DIFF
--- a/arguments.py
+++ b/arguments.py
@@ -15,6 +15,9 @@ MASTERS_STEP = "masters"
 WORKERS_STEP = "workers"
 POST_STEP = "post"
 
+# Default Assisted Installer URL (used in NAT mode)
+DEFAULT_AI_URL = "192.168.122.1"
+
 
 def all_steps() -> list[str]:
     return [PRE_STEP, MASTERS_STEP, WORKERS_STEP, POST_STEP]
@@ -87,7 +90,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument('-v', '--verbosity', choices=['debug', 'info', 'warning', 'error', 'critical'], default='info', help='Set the logging level (default: info)')
     parser.add_argument('--secret', dest='secrets_path', default='', action='store', type=str, help='pull_secret.json path (default is in cwd)')
     parser.add_argument('--cda-config', dest='cda_config', default='/root/cda-config.yaml', action='store', type=str, help='defaults to /root/cda-config.yaml')
-    parser.add_argument('--assisted-installer-url', dest='url', default='192.168.122.1', action='store', type=str, help='If set to 0.0.0.0 (the default), Assisted Installer will be started locally')
+    parser.add_argument('--assisted-installer-url', dest='url', default=DEFAULT_AI_URL, action='store', type=str, help='Assisted Installer URL. Auto-detected for bridge mode.')
 
     subparsers = parser.add_subparsers(title='subcommands', dest='subcommand')
 

--- a/assistedInstallerService.py
+++ b/assistedInstallerService.py
@@ -84,12 +84,13 @@ class AssistedInstallerService:
     CONTROLLER_IMAGE = "registry.redhat.io/rhai/assisted-installer-controller-rhel9:38eb19a9a5ae047e047dd29f8979c6595bba9150"
     AGENT_DOCKER_IMAGE = "registry.redhat.io/rhai/assisted-installer-agent-rhel9:d30a801984dd4d26d2be2a9682bf638b1545595b"
 
-    def __init__(self, version: str, ip: str, resume_deployment: bool = False, proxy: Optional[str] = None, noproxy: Optional[str] = None, branch: str = "master"):
+    def __init__(self, version: str, ip: str, resume_deployment: bool = False, proxy: Optional[str] = None, noproxy: Optional[str] = None, branch: str = "master", bridge_name: str = "virbr0"):
         self._version = version
         self._ip = ip
         self._proxy = proxy
         self._noproxy = noproxy
         self._resume_deployment = resume_deployment
+        self._bridge_name = bridge_name
         base_url = f"https://raw.githubusercontent.com/openshift/assisted-service/{branch}"
         pod_config_url = f"{base_url}/deploy/podman/configmap.yml"
         pod_file = f"{base_url}/deploy/podman/pod-persistent.yml"
@@ -510,8 +511,10 @@ class AssistedInstallerService:
 
     def _ensure_libvirt_running(self) -> None:
         lh = host.LocalHost()
-        if not common.ip_links(lh, ifname="virbr0"):
-            logger.info("Can't find virbr0. Trying to restart libvirt.")
+        bridge = self._bridge_name
+
+        if not common.ip_links(lh, ifname=bridge):
+            logger.info(f"Can't find {bridge}. Trying to restart libvirt.")
             libvirt = Libvirt(lh)
             libvirt.configure()
             cmd = "virsh net-start default"
@@ -521,8 +524,8 @@ class AssistedInstallerService:
             # Need to find out if/how we can remove this to speed up.
             time.sleep(5)
 
-        if not common.ip_links(lh, ifname="virbr0"):
-            logger.error_and_exit("Can't find virbr0. Make sure that libvirt is running.")
+        if not common.ip_links(lh, ifname=bridge):
+            logger.error_and_exit(f"Can't find {bridge}. Make sure that libvirt is running.")
 
     def wait_for_api(self) -> None:
         self._ensure_libvirt_running()

--- a/cda.py
+++ b/cda.py
@@ -6,7 +6,7 @@ from assistedInstallerService import AssistedInstallerService
 from clustersConfig import ClustersConfig, ExtraConfigArgs
 from clusterDeployer import ClusterDeployer
 from isoDeployer import IsoDeployer
-from arguments import parse_args
+from arguments import parse_args, DEFAULT_AI_URL
 import argparse
 import host
 from logger import logger
@@ -15,6 +15,7 @@ from virtualBridge import VirBridge
 import configLoader
 from cdaConfig import CdaConfig
 import auth
+import common
 import os
 from state_file import StateFile
 
@@ -27,18 +28,52 @@ def check_and_cleanup_disk(threshold_gb: int = 10) -> None:
         h.run("podman image prune -a -f")
 
 
+def get_ai_url_for_bridge_mode(cc: ClustersConfig, args: argparse.Namespace) -> tuple[str, bool]:
+    """Get the Assisted Installer URL, auto-detecting for bridge mode.
+
+    In bridge mode, the default NAT URL (192.168.122.1) doesn't exist.
+    We use the IP of the kernel bridge instead, so the AI is reachable from VMs.
+
+    Returns:
+        Tuple of (ai_url, start_locally) where start_locally indicates if AI should be started.
+    """
+    # If user explicitly specified a URL different from default, use it (external AI)
+    if args.url != DEFAULT_AI_URL:
+        return args.url, False
+
+    # NAT mode: use the default, start AI locally
+    if cc.network_mode != "bridge":
+        return args.url, True
+
+    # Bridge mode: get IP of the kernel bridge, start AI locally
+    bridge_ip = common.port_to_ip(host.LocalHost(), cc.bridge_name)
+    if bridge_ip is None:
+        logger.error_and_exit(
+            f"Bridge mode is enabled but could not get IP of bridge '{cc.bridge_name}'. "
+            f"Make sure the bridge exists and has an IP address. "
+            f"You can create it with: scripts/setup-bridge.sh <interface> {cc.bridge_name}"
+        )
+
+    logger.info(f"Bridge mode: using {bridge_ip} as Assisted Installer URL (from {cc.bridge_name})")
+    return bridge_ip, True
+
+
 def main_deploy_openshift(cc: ClustersConfig, args: argparse.Namespace, state_file: StateFile) -> None:
     # Make sure the local virtual bridge base configuration is correct.
     local_bridge = VirBridge(host.LocalHost(), cc.local_bridge_config)
     local_bridge.configure(api_port=None)
 
-    # microshift does not use assisted installer so we don't need this check
-    if args.url == cc.ip_range[0]:
+    # Get the appropriate AI URL (auto-detected for bridge mode)
+    ai_url, start_ai_locally = get_ai_url_for_bridge_mode(cc, args)
+
+    if start_ai_locally:
         resume_deployment = "master" not in args.steps
-        ais = AssistedInstallerService(cc.version, args.url, resume_deployment, cc.proxy, cc.noproxy)
+        # Use the appropriate bridge name based on network mode
+        bridge_name = cc.bridge_name if cc.network_mode == "bridge" else "virbr0"
+        ais = AssistedInstallerService(cc.version, ai_url, resume_deployment, cc.proxy, cc.noproxy, bridge_name=bridge_name)
         ais.start()
     else:
-        logger.info(f"Will use Assisted Installer running at {args.url}")
+        logger.info(f"Will use Assisted Installer running at {ai_url}")
         ais = None
 
     """
@@ -47,7 +82,7 @@ def main_deploy_openshift(cc: ClustersConfig, args: argparse.Namespace, state_fi
     The usage details are here:
         https://aicli.readthedocs.io/en/latest/
     """
-    ai = AssistedClientAutomation(f"{args.url}:8090", ais)
+    ai = AssistedClientAutomation(f"{ai_url}:8090", ais)
     cd = ClusterDeployer(cc, ai, args.steps, args.secrets_path, state_file, args.resume)
 
     if args.additional_post_config:

--- a/clusterConfigSchema.yml
+++ b/clusterConfigSchema.yml
@@ -5,6 +5,8 @@ clusters:
     ingress_vip: "..."
     external_port: "<device name> optional, detected automatically"
     network_api_port: "<auto / device name>"
+    network_mode: "<nat / bridge> - default: nat. Use 'bridge' for hybrid VM+physical deployments on same L2 network"
+    bridge_name: "<kernel bridge name> - default: br-cda-0. Required when network_mode=bridge. Must be pre-created on host"
     ip_range: "IP range (<start>-<end>) to use for connectivity between cluster nodes (optional)"
     ip_mask: "IP mask (x.y.z.t) to use for connectivity between cluster nodes (optional)"
     masters:

--- a/clusterDeployer.py
+++ b/clusterDeployer.py
@@ -518,18 +518,20 @@ class ClusterDeployer(BaseDeployer):
         if not node.wait_for_boot(self._cc.full_ip_range):
             return False
 
-        if not master and not self._rename_worker(node):
+        # Rename workers always, and masters in bridge mode (external DHCP assigns FQDN hostnames)
+        needs_rename = not master or self._cc.network_mode == "bridge"
+        if needs_rename and not self._rename_worker(node):
             return False
 
         return self._wait_known(node)
 
     def _rename_worker(self, node: ClusterNode) -> bool:
-        logger.info(f"Waiting for connectivity to worker {node.config.name}")
+        logger.info(f"Waiting for connectivity to {node.config.name}")
         rh = host.RemoteHost(node.ip())
         rh.ssh_connect("core")
 
         ip_range = self._cc.full_ip_range
-        logger.info(f"Connectivity established to worker {node.config.name} checking that it has an IP in range: {ip_range}")
+        logger.info(f"Connectivity established to {node.config.name}, checking that it has an IP in range: {ip_range}")
 
         def any_address_in_range(h: host.Host, ip_range: tuple[str, str]) -> bool:
             for ipaddr in common.ip_addrs(h):
@@ -542,7 +544,7 @@ class ClusterDeployer(BaseDeployer):
             return False
 
         if not any_address_in_range(rh, ip_range):
-            logger.error(f"Worker {node.config.name} doesn't have an IP in range {ip_range}.")
+            logger.error(f"Node {node.config.name} doesn't have an IP in range {ip_range}.")
             return False
 
         logger.info(f"Waiting for {node.config.name} rename to succeed")

--- a/clusterHost.py
+++ b/clusterHost.py
@@ -151,7 +151,8 @@ class ClusterHost:
             logger.info(f"No master set for interface {self.api_port}, setting it to {br_name}")
             self.hostconn.run(f"ip link set {self.api_port} master {br_name}")
         elif interface.master != br_name:
-            logger.error_and_exit(f"Incorrect master set for interface {self.api_port}")
+            logger.error_and_exit(f"Interface {self.api_port} is already attached to bridge '{interface.master}', cannot use it for {br_name}. "
+                                  f"Please set 'network_api_port' in your cluster config to specify a different interface.")
 
         logger.info(f"Setting interface {self.api_port} as unmanaged in NetworkManager")
         self.hostconn.run(f"nmcli device set {self.api_port} managed no")

--- a/clusterHost.py
+++ b/clusterHost.py
@@ -72,9 +72,10 @@ class ClusterHost:
             if not self.hostconn.is_localhost():
                 self.hostconn.ssh_connect(self.config.username, self.config.password)
 
-        # This host needs an api network port if it runs vms and there are more
-        # than one physical host in the deployment.
-        self.needs_api_network = (self.hosts_vms and any(node_config.node != c.name for node_config in cc.all_nodes())) or self.hostconn.is_localhost()
+        # This host needs an api network port if it runs vms and there are
+        # physical nodes or nodes on other hosts in the deployment.
+        has_external_nodes = any(node_config.node != c.name or node_config.kind != "vm" for node_config in cc.all_nodes())
+        self.needs_api_network = self.hosts_vms and has_external_nodes
         if self.needs_api_network:
             if self.config.network_api_port == "auto":
                 self.api_port = common.get_auto_port(self.hostconn)

--- a/clusterHost.py
+++ b/clusterHost.py
@@ -131,6 +131,12 @@ class ClusterHost:
         self.ensure_linked_to_network(self.bridge)
 
     def ensure_linked_to_network(self, dhcp_bridge: VirBridge) -> None:
+        # In bridge mode, VMs connect directly to the pre-existing kernel bridge
+        # No need to add physical interface as slave or configure DHCP filtering
+        if dhcp_bridge.is_bridge_mode():
+            logger.info("Bridge mode: skipping network linking (using pre-existing kernel bridge)")
+            return
+
         if not self.needs_api_network:
             return
         assert self.api_port is not None
@@ -159,6 +165,11 @@ class ClusterHost:
         self.hostconn.run(f"nmcli device set {self.api_port} managed no")
 
     def ensure_not_linked_to_network(self) -> None:
+        # In bridge mode, we didn't do any linking, so nothing to undo
+        if self.bridge.is_bridge_mode():
+            logger.info("Bridge mode: skipping network unlinking (nothing was linked)")
+            return
+
         if not self.needs_api_network:
             return
         assert self.api_port is not None

--- a/clustersConfig.py
+++ b/clustersConfig.py
@@ -203,6 +203,8 @@ class BridgeConfig:
     ip: str
     mask: str
     dynamic_ip_range: Optional[tuple[str, str]] = None
+    mode: str = "nat"  # "nat" or "bridge"
+    bridge_name: str = "virbr0"  # kernel bridge name for bridge mode
 
 
 class ClustersConfig:
@@ -214,6 +216,8 @@ class ClustersConfig:
     kind: str
     version: str
     network_api_port: str
+    network_mode: str
+    bridge_name: str
     masters: list[NodeConfig]
     workers: list[NodeConfig]
     configured_workers: list[NodeConfig]
@@ -243,6 +247,8 @@ class ClustersConfig:
         self.kind = "openshift"
         self.version = "4.14.0-nightly"
         self.network_api_port = "auto"
+        self.network_mode = "nat"
+        self.bridge_name = "br-cda-0"
         self.masters: list[NodeConfig] = []
         self.workers: list[NodeConfig] = []
         self.configured_workers: list[NodeConfig] = []
@@ -276,6 +282,12 @@ class ClustersConfig:
                 self.install_iso = cc["install_iso"]
         if "network_api_port" in cc:
             self.network_api_port = cc["network_api_port"]
+        if "network_mode" in cc:
+            self.network_mode = cc["network_mode"]
+            if self.network_mode not in ("nat", "bridge"):
+                logger.error_and_exit(f"Invalid network_mode '{self.network_mode}'. Must be 'nat' or 'bridge'.")
+        if "bridge_name" in cc:
+            self.bridge_name = cc["bridge_name"]
         self.name = cc["name"]
         if "ntp_source" in cc:
             self.ntp_source = cc["ntp_source"]
@@ -355,8 +367,19 @@ class ClustersConfig:
             logger.error_and_exit("The supplied ip_range config is too small for the number of nodes")
 
         dynamic_ip_range = common.ip_range(self.ip_range[1], common.ip_range_size(ip_range) - common.ip_range_size(self.ip_range))
-        self.local_bridge_config = BridgeConfig(ip=self.ip_range[0], mask=ip_mask, dynamic_ip_range=dynamic_ip_range)
-        self.remote_bridge_config = BridgeConfig(ip=ip_range[1], mask=ip_mask)
+        self.local_bridge_config = BridgeConfig(
+            ip=self.ip_range[0],
+            mask=ip_mask,
+            dynamic_ip_range=dynamic_ip_range,
+            mode=self.network_mode,
+            bridge_name=self.bridge_name,
+        )
+        self.remote_bridge_config = BridgeConfig(
+            ip=ip_range[1],
+            mask=ip_mask,
+            mode=self.network_mode,
+            bridge_name=self.bridge_name,
+        )
 
     def get_last_ip(self) -> str | None:
         hostconn = host.LocalHost()

--- a/clustersConfig.py
+++ b/clustersConfig.py
@@ -338,7 +338,8 @@ class ClustersConfig:
         n_nodes = len(cc["masters"]) + len(cc["workers"]) + 1
 
         # Get the last IP used in the running cluster.
-        last_ip = self.get_last_ip()
+        # Default to 0.0.0.0 if network doesn't exist, so we still consider node IPs from config.
+        last_ip = self.get_last_ip() or "0.0.0.0"
 
         # Update the last IP based on the config.
         for node in self.all_nodes():

--- a/common.py
+++ b/common.py
@@ -479,6 +479,9 @@ def get_auto_port(host: host.Host) -> str:
         if not ipa.has_carrier():
             # No carrier, this interface is not a candidate.
             return False
+        if ipa.master is not None:
+            # Already attached to a bridge (e.g., podman, docker), skip it.
+            return False
         if any(ai.family == 'inet' or (ai.family == 'inet6' and not ai.local.startswith("fe80:")) for ai in ipa.addr_info):
             # We expect that there is no IP address. However, Ipv6 link local
             # addresses may be configured (for example, if NetworkManager in

--- a/dnsutil.py
+++ b/dnsutil.py
@@ -95,6 +95,12 @@ def _resolvconf_ensure_orig() -> None:
         logger.info(f"resolv.conf: point {RESOLVCONF_ORIG} to /run/NetworkManager/resolv.conf")
         lh = host.LocalHost()
         lh.run_or_die(f"ln -snf /run/NetworkManager/resolv.conf {RESOLVCONF_ORIG}")
+    elif b"systemd-resolved" in rc_content_orig and os.path.exists("/run/systemd/resolve/resolv.conf"):
+        # This is the systemd-resolved stub (127.0.0.53). Use the real resolv.conf
+        # which contains actual upstream DNS servers, not the stub.
+        logger.info(f"resolv.conf: point {RESOLVCONF_ORIG} to /run/systemd/resolve/resolv.conf")
+        lh = host.LocalHost()
+        lh.run_or_die(f"ln -snf /run/systemd/resolve/resolv.conf {RESOLVCONF_ORIG}")
     else:
         logger.info(f"resolv.conf: write {RESOLVCONF_ORIG}")
         with common.atomic_write(RESOLVCONF_ORIG, text=False) as f:

--- a/nfs.py
+++ b/nfs.py
@@ -41,10 +41,13 @@ class NFS:
 
     def _add(self, dir_name: str) -> None:
         contents = self._host.read_file("/etc/exports")
-        self._host.write("/etc/exports", f"{contents}\n{dir_name}")
+        # Export options: ro for ISO hosting, insecure for BMC/iDRAC access
+        export_line = f"{dir_name} *(ro,sync,no_root_squash,insecure,no_subtree_check)"
+        self._host.write("/etc/exports", f"{contents}\n{export_line}")
 
     def _export_fs(self) -> None:
         self._host.run("systemctl enable nfs-server")
+        self._configure_firewall()
         started_at = time.monotonic()
         while True:
             ret = self._host.run("systemctl restart nfs-server")
@@ -52,10 +55,25 @@ class NFS:
                 break
             if time.monotonic() > started_at + 60:
                 logger.error_and_exit(f"failed to `systemctl restart nfs-server`: {ret}")
-            ret = self._host.run("sudo systemctl disable --now firewalld")
-            if ret.success():
-                break
             time.sleep(1)
+
+    def _configure_firewall(self) -> None:
+        """Configure firewall to allow NFS traffic."""
+        # Check if firewalld is running
+        ret = self._host.run("systemctl is-active firewalld")
+        if not ret.success():
+            logger.info("firewalld not active, skipping firewall configuration")
+            return
+
+        # Add NFS services to firewall
+        nfs_services = ["nfs", "nfs3", "mountd", "rpc-bind"]
+        for service in nfs_services:
+            ret = self._host.run(f"firewall-cmd --query-service={service}")
+            if not ret.success():
+                logger.info(f"Adding {service} to firewall")
+                self._host.run(f"firewall-cmd --add-service={service} --permanent")
+
+        self._host.run("firewall-cmd --reload")
 
     def _ip(self) -> Optional[str]:
         return common.port_to_ip(self._host, self._port)

--- a/scripts/setup-bridge.sh
+++ b/scripts/setup-bridge.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+#
+# Setup script for creating a kernel bridge for CDA bridge mode deployments.
+#
+# This script creates a kernel bridge that allows libvirt VMs to be on the
+# same L2 network as physical hosts. The bridge uses the interface's MAC
+# address so DHCP will assign the same IP.
+#
+# Usage:
+#   ./setup-bridge.sh <interface> [bridge_name]
+#
+# Example:
+#   ./setup-bridge.sh eno8303
+#   ./setup-bridge.sh eno8303 br-cda-0
+#
+# WARNING: Network connectivity will be briefly interrupted.
+#
+
+set -e
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+log_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 <interface> [bridge_name]"
+    echo "Example: $0 eno8303"
+    exit 1
+fi
+
+INTERFACE="$1"
+BRIDGE_NAME="${2:-br-cda-0}"
+
+if ! ip link show "$INTERFACE" &>/dev/null; then
+    log_error "Interface $INTERFACE does not exist"
+    exit 1
+fi
+
+if [ "$EUID" -ne 0 ]; then
+    log_error "This script must be run as root"
+    exit 1
+fi
+
+if ip link show "$BRIDGE_NAME" &>/dev/null; then
+    if ip link show "$INTERFACE" 2>/dev/null | grep -q "master $BRIDGE_NAME"; then
+        log_info "Bridge $BRIDGE_NAME already exists with $INTERFACE as member"
+        exit 0
+    else
+        log_error "Bridge $BRIDGE_NAME exists but $INTERFACE is not part of it"
+        exit 1
+    fi
+fi
+
+# Get MAC address from the interface
+MAC_ADDRESS=$(ip link show "$INTERFACE" | grep -oP 'link/ether \K[^ ]+')
+CURRENT_CONN=$(nmcli -t -f NAME,DEVICE connection show --active 2>/dev/null | grep ":${INTERFACE}$" | cut -d: -f1 || true)
+
+log_info "Creating bridge $BRIDGE_NAME with MAC $MAC_ADDRESS from $INTERFACE"
+log_info "DHCP will assign the same IP as before"
+echo ""
+log_warn "WARNING: Network connectivity will be briefly interrupted!"
+read -p "Continue? [y/N] " -n 1 -r
+echo ""
+
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    log_info "Aborted."
+    exit 0
+fi
+
+# Create bridge with same MAC as the interface
+nmcli connection add type bridge ifname "$BRIDGE_NAME" con-name "$BRIDGE_NAME"
+nmcli connection modify "$BRIDGE_NAME" bridge.stp no
+nmcli connection modify "$BRIDGE_NAME" ethernet.cloned-mac-address "$MAC_ADDRESS"
+nmcli connection modify "$BRIDGE_NAME" ipv4.method auto
+
+# Add interface as slave
+nmcli connection add type bridge-slave ifname "$INTERFACE" master "$BRIDGE_NAME" con-name "${BRIDGE_NAME}-slave"
+
+# Activate bridge
+log_info "Activating bridge..."
+[ -n "$CURRENT_CONN" ] && nmcli connection down "$CURRENT_CONN" 2>/dev/null || true
+nmcli connection up "$BRIDGE_NAME"
+
+log_info "Bridge setup complete!"
+ip addr show "$BRIDGE_NAME"

--- a/virtualBridge.py
+++ b/virtualBridge.py
@@ -216,6 +216,9 @@ class VirBridge:
             # We need to investigate how to remove the sleep to speed up
             time.sleep(5)
 
+            # Re-fetch network XML after reconfiguration so the DHCP range check below uses current state
+            ret = self.hostconn.run(cmd)
+
         # Reconfiguring bridge by deleting and recreating it causes existing bridge configuration (dhcp entries, bridge masters...) to get lost.
         # The dynamic range might change if we add workers. Update dynamic range ... dynamically, without restarting bridge, to avoid
         # losing existing bridge config.

--- a/virtualBridge.py
+++ b/virtualBridge.py
@@ -40,7 +40,16 @@ class VirBridge:
         self.config = config
         self.libvirt = Libvirt(h)
 
+    def is_bridge_mode(self) -> bool:
+        """Check if using bridge-forward mode (vs NAT mode)."""
+        return self.config.mode == "bridge"
+
     def setup_dhcp_entries(self, nodes: list[NodeConfig]) -> None:
+        # In bridge mode, we use external DHCP - skip libvirt DHCP configuration
+        if self.is_bridge_mode():
+            logger.info("Bridge mode: skipping DHCP setup (using external DHCP)")
+            return
+
         # DHCP entries should have been removed during teardown.
         # However, leases sometimes came back.
         self.remove_dhcp_entries(nodes)
@@ -58,6 +67,11 @@ class VirBridge:
             self.hostconn.run_or_die(cmd)
 
     def remove_dhcp_entries(self, nodes: list[NodeConfig]) -> None:
+        # In bridge mode, we use external DHCP - nothing to remove
+        if self.is_bridge_mode():
+            logger.info("Bridge mode: skipping DHCP cleanup (using external DHCP)")
+            return
+
         def filter_dhcp_leases(j: list[dict[str, str]], removed_macs: list[str], names: list[str]) -> list[dict[str, str]]:
             filtered = []
             for entry in j:
@@ -137,7 +151,8 @@ class VirBridge:
         if api_port is not None:
             self.hostconn.run(f"ip link set {api_port} up")
 
-    def _network_xml(self) -> str:
+    def _network_xml_nat(self) -> str:
+        """Generate libvirt network XML for NAT mode (original behavior)."""
         if self.config.dynamic_ip_range is None:
             dhcp_part = ""
         else:
@@ -155,6 +170,26 @@ class VirBridge:
                 </ip>
                 </network>"""
 
+    def _network_xml_bridge(self) -> str:
+        """Generate libvirt network XML for bridge-forward mode.
+
+        This mode connects VMs directly to a pre-existing kernel bridge,
+        allowing them to be on the same L2 network as physical hosts.
+        No IP/DHCP is configured on the libvirt side - external DHCP is used.
+        """
+        return f"""
+                <network>
+                <name>default</name>
+                <forward mode='bridge'/>
+                <bridge name='{self.config.bridge_name}'/>
+                </network>"""
+
+    def _network_xml(self) -> str:
+        """Generate appropriate network XML based on configured mode."""
+        if self.config.mode == "bridge":
+            return self._network_xml_bridge()
+        return self._network_xml_nat()
+
     def _ensure_run_as_root(self) -> None:
         qemu_conf = self.hostconn.read_file("/etc/libvirt/qemu.conf")
         if re.search('\nuser = "root"', qemu_conf) and re.search('\nuser = "root"', qemu_conf):
@@ -162,12 +197,67 @@ class VirBridge:
         self.hostconn.run("sed -e 's/#\\(user\\|group\\) = \".*\"$/\\1 = \"root\"/' -i /etc/libvirt/qemu.conf")
         self.libvirt.restart("qemu")
 
+    def _configure_bridge_mode(self) -> None:
+        """Configure libvirt network in bridge-forward mode.
+
+        This is a simpler configuration that just connects to a pre-existing
+        kernel bridge. No IP or DHCP configuration is done on the libvirt side.
+        """
+        hostname = self.hostconn.hostname()
+
+        cmd = "virsh net-dumpxml default"
+        ret = self.hostconn.run(cmd)
+
+        # Check if already configured correctly for bridge mode
+        needs_reconfigure = False
+        if ret.returncode != 0:
+            logger.info("Bridge needs to be configured: default network does not exist")
+            needs_reconfigure = True
+        elif "mode='bridge'" not in ret.out:
+            logger.info("Bridge needs to be reconfigured: not in bridge forward mode")
+            needs_reconfigure = True
+        elif f"name='{self.config.bridge_name}'" not in ret.out:
+            logger.info(f"Bridge needs to be reconfigured: wrong bridge name (expected {self.config.bridge_name})")
+            needs_reconfigure = True
+
+        active_ret = self.hostconn.run("virsh net-info default | grep Active")
+        if "no" in active_ret.out:
+            logger.info("Bridge needs to be reconfigured: the default network is down")
+            needs_reconfigure = True
+
+        if needs_reconfigure:
+            logger.info(f"Configuring bridge-forward network using kernel bridge {self.config.bridge_name}")
+            logger.info(f"creating default-net.xml on {hostname}")
+            contents = self._network_xml_bridge()
+
+            bridge_xml = os.path.join("/tmp", 'vir_bridge.xml')
+            self.hostconn.write(bridge_xml, contents)
+
+            # Destroy existing network if any
+            self.hostconn.run("virsh net-destroy default")
+            self.hostconn.run("virsh net-undefine default")
+
+            # Define and start the bridge-forward network
+            self.hostconn.run_or_die(f"virsh net-define {bridge_xml}")
+            self.hostconn.run_or_die("virsh net-start default")
+            self.hostconn.run_or_die("virsh net-autostart default")
+
+            logger.info("Bridge-forward network configured successfully")
+        else:
+            logger.info("Bridge-forward network already configured correctly")
+
     def configure(self, api_port: Optional[str]) -> None:
         hostname = self.hostconn.hostname()
         self.libvirt.configure()
 
         self._ensure_run_as_root()
 
+        # Bridge mode has simpler configuration - just connect to existing kernel bridge
+        if self.config.mode == "bridge":
+            self._configure_bridge_mode()
+            return
+
+        # NAT mode: full configuration with IP, DHCP, STP checks
         # stp must be disabled or it might conflict with default configuration of some physical switches
         # 'bridge' section of network 'default' can't be updated => destroy and recreate
         # check that default exists and contains stp=off


### PR DESCRIPTION
## Summary

This PR contains networking fixes and enhancements to improve deployment reliability, particularly for hybrid VM+physical node clusters and fresh system deployments.

### New Features

- **Bridge network mode**: Add support for deploying clusters with VM masters and physical workers on the same L2 network. The new `network_mode: bridge` option uses libvirt's bridge-forward mode instead of NAT, connecting VMs to a pre-existing kernel bridge. Includes `scripts/setup-bridge.sh` helper script.

### Bug Fixes

- **NFS exports**: Fix invalid `/etc/exports` entries by adding proper export options (ro, sync, no_root_squash, insecure, no_subtree_check). Also configure firewall rules for NFS instead of requiring firewalld to be disabled.

- **systemd-resolved handling**: Detect when `/etc/resolv.conf` is the systemd-resolved stub (127.0.0.53) and use the real upstream resolvers from `/run/systemd/resolve/resolv.conf` to avoid DNS loops.

- **Localhost cluster api_port**: Don't require `api_port` for fully virtual localhost clusters where all nodes are VMs communicating via virbr0.

- **Bridged interface exclusion**: Exclude interfaces already attached to a bridge (e.g., podman, docker) from auto port selection to avoid breaking their networking.

- **IP range calculation**: Fix node IP range calculation on fresh systems where the libvirt default network doesn't exist yet, which was causing "Node IP not in cluster subnet range" errors.

- **DHCP range duplication**: Fix "existing dhcp range entry" error after bridge recreation by re-fetching network XML after reconfiguration.